### PR TITLE
This handles good breakdown in bicgstab(ell)

### DIFF
--- a/amgcl/solver/bicgstabl.hpp
+++ b/amgcl/solver/bicgstabl.hpp
@@ -159,7 +159,12 @@ class bicgstabl {
                         P.apply(*u[j], *q);
                         backend::spmv(1, A, *q, 0, *u[j+1]);
 
-                        alpha = rho0 / inner_product(*u[j+1], *r0);
+                        alpha = inner_product(*u[j+1], *r0);
+                        if (fabs(alpha) < amgcl::detail::eps<value_type>(1)) {
+                            ++iter;
+                            goto check_residual;
+                        }
+                        alpha = rho0 / alpha;
 
                         for(int i = 0; i <= j; ++i)
                             backend::axpby(-alpha, *u[i+1], 1, *r[i]);
@@ -206,6 +211,7 @@ class bicgstabl {
                     res_norm = norm(*r[0]);
                 }
 
+check_residual:
                 P.apply(x, *q);
                 backend::copy(*q, x);
                 backend::residual(rhs, A, x, *r0);


### PR DESCRIPTION
The breakdown may occur if solution obtained on a previous iteration of
Bi-CG part bicgstab(ell) is exact. This may happen if amg hierarchy
consists of a single level (that is, the problem is too small).
