### PR TITLE
Improve work with null-space vectors for non-scalar systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,22 +296,14 @@ library.
   [amgcl/coarsening/ruge_stuben.hpp]). Ruge-Stuben coarsening usually results
   in a more efficient multigrid cycles at the price of increased construction
   time and higher memory requirements.
-- Aggregation based coarsening strategies. Aggregation based coarseners are
-  implemented as class templates with a single template parameter. The
-  parameter controls how fine-level variables are subdivided into aggregates.
-  Possible choices are `amgcl::coarsening::plain_aggregates`
-  ([amgcl/coarsening/plain_aggregates.hpp][]) and
-  `amgcl::coarsening::pointwise_aggregates`
-  ([amgcl/coarsening/pointwise_aggregates.hpp][]). The latter may be used when
-  a system of coupled PDEs is solved. In this case the aggregation
-  acts on grid points instead of individual variables.
-  - Non-smoothed aggregation: `amgcl::coarsening::aggregation<Aggregates>`
+- Aggregation based coarsening strategies.
+  - Non-smoothed aggregation: `amgcl::coarsening::aggregation`
     ([amgcl/coarsening/aggregation.hpp][]).
   - Smoothed aggregation:
-    `amgcl::coarsening::smoothed_aggregation<Aggregates>`
+    `amgcl::coarsening::smoothed_aggregation`
     ([amgcl/coarsening/smoothed_aggregation.hpp][]).
   - Smoothed aggregation with energy minimization (see [6]):
-    `amgcl::coarsening::smoothed_aggr_emin<Aggregates>`
+    `amgcl::coarsening::smoothed_aggr_emin`
     ([amgcl/coarsening/smoothed_aggr_emin.hpp][]).
 
 In many cases the best choice is the smoothed aggregation coarsening. It
@@ -539,8 +531,6 @@ partially supported by RFBR grants No 12-07-0007 and 12-01-00033._
 [amgcl/coarsening/aggregation.hpp]:          amgcl/coarsening/aggregation.hpp
 [amgcl/coarsening/smoothed_aggregation.hpp]: amgcl/coarsening/smoothed_aggregation.hpp
 [amgcl/coarsening/smoothed_aggr_emin.hpp]:   amgcl/coarsening/smoothed_aggr_emin.hpp
-[amgcl/coarsening/plain_aggregates.hpp]:     amgcl/coarsening/plain_aggregates.hpp
-[amgcl/coarsening/pointwise_aggregates.hpp]: amgcl/coarsening/pointwise_aggregates.hpp
 
 [amgcl/relaxation/damped_jacobi.hpp]: amgcl/relaxation/damped_jacobi.hpp
 [amgcl/relaxation/spai0.hpp]:         amgcl/relaxation/spai0.hpp

--- a/amgcl/coarsening/aggregation.hpp
+++ b/amgcl/coarsening/aggregation.hpp
@@ -37,6 +37,7 @@ THE SOFTWARE.
 
 #include <amgcl/backend/builtin.hpp>
 #include <amgcl/coarsening/detail/scaled_galerkin.hpp>
+#include <amgcl/coarsening/pointwise_aggregates.hpp>
 #include <amgcl/coarsening/tentative_prolongation.hpp>
 #include <amgcl/util.hpp>
 
@@ -65,11 +66,11 @@ namespace coarsening {
 
 /// Non-smoothed aggregation.
 /**
- * \param Aggregates \ref aggregates formation.
  * \ingroup coarsening
  */
-template <class Aggregates>
 struct aggregation {
+    typedef pointwise_aggregates Aggregates;
+
     /// Coarsening parameters.
     struct params {
         /// Aggregation parameters.
@@ -131,12 +132,15 @@ struct aggregation {
 
         TIC("interpolation");
         boost::shared_ptr<Matrix> P = tentative_prolongation<Matrix>(
-                n, aggr.count, aggr.id, prm.nullspace
+                n, aggr.count, aggr.id, prm.nullspace, prm.aggr.block_size
                 );
         TOC("interpolation");
 
         boost::shared_ptr<Matrix> R = boost::make_shared<Matrix>();
         *R = transpose(*P);
+
+        if (prm.nullspace.cols > 0)
+            prm.aggr.block_size = prm.nullspace.cols;
 
         return boost::make_tuple(P, R);
     }

--- a/amgcl/coarsening/smoothed_aggregation.hpp
+++ b/amgcl/coarsening/smoothed_aggregation.hpp
@@ -39,6 +39,7 @@ THE SOFTWARE.
 
 #include <amgcl/backend/builtin.hpp>
 #include <amgcl/coarsening/detail/galerkin.hpp>
+#include <amgcl/coarsening/pointwise_aggregates.hpp>
 #include <amgcl/coarsening/tentative_prolongation.hpp>
 #include <amgcl/util.hpp>
 
@@ -47,12 +48,12 @@ namespace coarsening {
 
 /// Smoothed aggregation coarsening.
 /**
- * \param Aggregates \ref aggregates formation.
  * \ingroup coarsening
  * \sa \cite Vanek1996
  */
-template <class Aggregates>
 struct smoothed_aggregation {
+    typedef pointwise_aggregates Aggregates;
+
     /// Coarsening parameters
     struct params {
         /// Aggregation parameters.
@@ -114,7 +115,7 @@ struct smoothed_aggregation {
 
         TIC("interpolation");
         boost::shared_ptr<Matrix> P_tent = tentative_prolongation<Matrix>(
-                n, aggr.count, aggr.id, prm.nullspace
+                n, aggr.count, aggr.id, prm.nullspace, prm.aggr.block_size
                 );
 
         boost::shared_ptr<Matrix> P = boost::make_shared<Matrix>();
@@ -213,6 +214,9 @@ struct smoothed_aggregation {
 
         boost::shared_ptr<Matrix> R = boost::make_shared<Matrix>();
         *R = transpose(*P);
+
+        if (prm.nullspace.cols > 0)
+            prm.aggr.block_size = prm.nullspace.cols;
 
         return boost::make_tuple(P, R);
     }

--- a/amgcl/coarsening/tentative_prolongation.hpp
+++ b/amgcl/coarsening/tentative_prolongation.hpp
@@ -47,14 +47,16 @@ namespace coarsening {
 namespace detail {
     struct skip_negative {
         const std::vector<ptrdiff_t> &key;
+        int block_size;
 
-        skip_negative(const std::vector<ptrdiff_t> &key) : key(key) { }
+        skip_negative(const std::vector<ptrdiff_t> &key, int block_size)
+            : key(key), block_size(block_size) { }
 
         bool operator()(ptrdiff_t i, ptrdiff_t j) const {
             // Cast to unsigned type to keep negative values at the end
             return
-                static_cast<size_t>(key[i]) <
-                static_cast<size_t>(key[j]);
+                static_cast<size_t>(key[i]) / block_size <
+                static_cast<size_t>(key[j]) / block_size;
         }
     };
 } // namespace detail
@@ -118,7 +120,8 @@ boost::shared_ptr<Matrix> tentative_prolongation(
         size_t n,
         size_t naggr,
         const std::vector<ptrdiff_t> aggr,
-        nullspace_params &nullspace
+        nullspace_params &nullspace,
+        int block_size
         )
 {
     typedef typename backend::value_type<Matrix>::type value_type;
@@ -133,13 +136,13 @@ boost::shared_ptr<Matrix> tentative_prolongation(
                 boost::counting_iterator<ptrdiff_t>(0),
                 boost::counting_iterator<ptrdiff_t>(n)
                 );
-        boost::stable_sort(order, detail::skip_negative(aggr));
+        boost::stable_sort(order, detail::skip_negative(aggr, block_size));
 
         // Precompute the shape of the prolongation operator.
         // Each row contains exactly nullspace.cols non-zero entries.
         // Rows that do not belong to any aggregate are empty.
         P->nrows = n;
-        P->ncols = naggr * nullspace.cols;
+        P->ncols = nullspace.cols * naggr / block_size;
         P->ptr.reserve(n + 1);
 
         P->ptr.push_back(0);
@@ -156,16 +159,16 @@ boost::shared_ptr<Matrix> tentative_prolongation(
         // Compute the tentative prolongation operator and null-space vectors
         // for the coarser level.
         std::vector<double> Bnew;
-        Bnew.reserve(naggr * nullspace.cols * nullspace.cols);
+        Bnew.reserve(naggr * nullspace.cols * nullspace.cols / block_size);
 
         size_t offset = 0;
 
         amgcl::detail::QR<double> qr;
         std::vector<double> Bpart;
-        for(ptrdiff_t i = 0; i < static_cast<ptrdiff_t>(naggr); ++i) {
+        for(ptrdiff_t i = 0; i < static_cast<ptrdiff_t>(naggr / block_size); ++i) {
             int d = 0;
             Bpart.clear();
-            for(size_t j = offset; j < n && aggr[order[j]] == i; ++j, ++d)
+            for(size_t j = offset; j < n && aggr[order[j]] / block_size == i; ++j, ++d)
                 std::copy(
                         &nullspace.B[nullspace.cols * order[j]],
                         &nullspace.B[nullspace.cols * order[j]] + nullspace.cols,

--- a/amgcl/mpi/runtime.hpp
+++ b/amgcl/mpi/runtime.hpp
@@ -291,25 +291,19 @@ inline void process_sdd(
         case runtime::coarsening::aggregation:
             process_sdd<
                 Backend,
-                amgcl::coarsening::aggregation<
-                    amgcl::coarsening::pointwise_aggregates
-                    >
+                amgcl::coarsening::aggregation
                 >(relaxation, iterative_solver, direct_solver, func);
             break;
         case runtime::coarsening::smoothed_aggregation:
             process_sdd<
                 Backend,
-                amgcl::coarsening::smoothed_aggregation<
-                    amgcl::coarsening::pointwise_aggregates
-                    >
+                amgcl::coarsening::smoothed_aggregation
                 >(relaxation, iterative_solver, direct_solver, func);
             break;
         case runtime::coarsening::smoothed_aggr_emin:
             process_sdd<
                 Backend,
-                amgcl::coarsening::smoothed_aggr_emin<
-                    amgcl::coarsening::pointwise_aggregates
-                    >
+                amgcl::coarsening::smoothed_aggr_emin
                 >(relaxation, iterative_solver, direct_solver, func);
             break;
     }

--- a/amgcl/runtime.hpp
+++ b/amgcl/runtime.hpp
@@ -42,7 +42,6 @@ THE SOFTWARE.
 
 #include <amgcl/backend/interface.hpp>
 #include <amgcl/coarsening/ruge_stuben.hpp>
-#include <amgcl/coarsening/pointwise_aggregates.hpp>
 #include <amgcl/coarsening/aggregation.hpp>
 #include <amgcl/coarsening/smoothed_aggregation.hpp>
 #include <amgcl/coarsening/smoothed_aggr_emin.hpp>
@@ -337,25 +336,19 @@ inline void process_amg(
         case runtime::coarsening::aggregation:
             process_amg<
                 Backend,
-                amgcl::coarsening::aggregation<
-                    amgcl::coarsening::pointwise_aggregates
-                    >
+                amgcl::coarsening::aggregation
                 >(relaxation, func);
             break;
         case runtime::coarsening::smoothed_aggregation:
             process_amg<
                 Backend,
-                amgcl::coarsening::smoothed_aggregation<
-                    amgcl::coarsening::pointwise_aggregates
-                    >
+                amgcl::coarsening::smoothed_aggregation
                 >(relaxation, func);
             break;
         case runtime::coarsening::smoothed_aggr_emin:
             process_amg<
                 Backend,
-                amgcl::coarsening::smoothed_aggr_emin<
-                    amgcl::coarsening::pointwise_aggregates
-                    >
+                amgcl::coarsening::smoothed_aggr_emin
                 >(relaxation, func);
             break;
     }

--- a/examples/block_crs.cpp
+++ b/examples/block_crs.cpp
@@ -6,7 +6,6 @@
 #include <amgcl/amgcl.hpp>
 
 #include <amgcl/backend/block_crs.hpp>
-#include <amgcl/coarsening/pointwise_aggregates.hpp>
 #include <amgcl/coarsening/aggregation.hpp>
 #include <amgcl/relaxation/spai0.hpp>
 #include <amgcl/solver/bicgstab.hpp>
@@ -21,9 +20,7 @@ int main() {
 
     typedef amgcl::amg<
         amgcl::backend::block_crs<double>,
-        amgcl::coarsening::aggregation<
-            amgcl::coarsening::pointwise_aggregates
-            >,
+        amgcl::coarsening::aggregation,
         amgcl::relaxation::spai0
         > AMG;
 

--- a/examples/cuda.cu
+++ b/examples/cuda.cu
@@ -2,7 +2,6 @@
 
 #include <amgcl/amgcl.hpp>
 
-#include <amgcl/coarsening/plain_aggregates.hpp>
 #include <amgcl/coarsening/smoothed_aggregation.hpp>
 #include <amgcl/relaxation/spai0.hpp>
 #include <amgcl/solver/bicgstab.hpp>
@@ -22,9 +21,7 @@ int main() {
 
     typedef amgcl::amg<
         amgcl::backend::cuda<double>,
-        amgcl::coarsening::smoothed_aggregation<
-            amgcl::coarsening::plain_aggregates
-            >,
+        amgcl::coarsening::smoothed_aggregation,
         amgcl::relaxation::spai0
         > AMG;
 

--- a/examples/hpx.cpp
+++ b/examples/hpx.cpp
@@ -5,7 +5,6 @@
 #include <amgcl/backend/hpx.hpp>
 #include <amgcl/adapter/crs_tuple.hpp>
 #include <amgcl/coarsening/smoothed_aggregation.hpp>
-#include <amgcl/coarsening/plain_aggregates.hpp>
 #include <amgcl/relaxation/spai0.hpp>
 #include <amgcl/solver/bicgstab.hpp>
 #include <amgcl/profiler.hpp>
@@ -34,9 +33,7 @@ int hpx_main(boost::program_options::variables_map &vm) {
 
     typedef amgcl::make_solver<
         Backend,
-        amgcl::coarsening::smoothed_aggregation<
-            amgcl::coarsening::plain_aggregates
-            >,
+        amgcl::coarsening::smoothed_aggregation,
         amgcl::relaxation::spai0,
         amgcl::solver::bicgstab
         > Solver;

--- a/examples/solver.cpp
+++ b/examples/solver.cpp
@@ -3,7 +3,6 @@
 #include <amgcl/amgcl.hpp>
 #include <amgcl/backend/builtin.hpp>
 #include <amgcl/adapter/crs_builder.hpp>
-#include <amgcl/coarsening/plain_aggregates.hpp>
 #include <amgcl/coarsening/smoothed_aggregation.hpp>
 #include <amgcl/relaxation/multicolor_gauss_seidel.hpp>
 #include <amgcl/solver/cg.hpp>
@@ -82,9 +81,7 @@ int main(int argc, char *argv[]) {
     prof.tic("build");
     amgcl::make_solver<
         amgcl::backend::builtin<double>,
-        amgcl::coarsening::smoothed_aggregation<
-            amgcl::coarsening::plain_aggregates
-            >,
+        amgcl::coarsening::smoothed_aggregation,
         amgcl::relaxation::multicolor_gauss_seidel,
         amgcl::solver::cg
         > solve( amgcl::adapter::make_matrix( poisson_2d(m) ) );

--- a/examples/ublas.cpp
+++ b/examples/ublas.cpp
@@ -9,7 +9,6 @@
 #include <amgcl/backend/builtin.hpp>
 #include <amgcl/adapter/ublas.hpp>
 #include <amgcl/coarsening/smoothed_aggregation.hpp>
-#include <amgcl/coarsening/plain_aggregates.hpp>
 #include <amgcl/relaxation/spai0.hpp>
 #include <amgcl/solver/bicgstabl.hpp>
 #include <amgcl/profiler.hpp>
@@ -50,9 +49,7 @@ int main(int argc, char *argv[]) {
     prof.tic("build");
     amgcl::make_solver<
         amgcl::backend::builtin<double>,
-        amgcl::coarsening::smoothed_aggregation<
-            amgcl::coarsening::plain_aggregates
-            >,
+        amgcl::coarsening::smoothed_aggregation,
         amgcl::relaxation::spai0,
         amgcl::solver::bicgstabl
         > solve( amgcl::backend::map(A) );

--- a/examples/vexcl.cpp
+++ b/examples/vexcl.cpp
@@ -3,7 +3,6 @@
 #include <amgcl/amgcl.hpp>
 #include <amgcl/backend/vexcl.hpp>
 #include <amgcl/adapter/crs_tuple.hpp>
-#include <amgcl/coarsening/plain_aggregates.hpp>
 #include <amgcl/coarsening/smoothed_aggregation.hpp>
 #include <amgcl/relaxation/spai0.hpp>
 #include <amgcl/solver/bicgstab.hpp>
@@ -33,9 +32,7 @@ int main(int argc, char *argv[]) {
 
     typedef amgcl::make_solver<
         amgcl::backend::vexcl<double>,
-        amgcl::coarsening::smoothed_aggregation<
-            amgcl::coarsening::plain_aggregates
-            >,
+        amgcl::coarsening::smoothed_aggregation,
         amgcl::relaxation::spai0,
         amgcl::solver::bicgstab
         > Solver;


### PR DESCRIPTION
Adjust block size for coarse levels when null-space is provided.

This is an API breaking change!
Remove `Aggregates` template parameter from aggregation-based coarseners.

Starting with this commit aggregation based coarseners (`amgcl::coarsening::aggregation`, `amgcl::coarsening::smoothed_aggregation`, `amgcl::coarsening::smoothed_aggr_emin`) always use `amgcl::coarsening::pointwise_aggregates` for aggregation.

The change is required since scalar problem may become non-scalar if
near null-space vectors are provided. The `amgcl::runtime` interface has not
changed since `runtime` class versions were based on `pointwise_aggregates`
anyway.