### PR TITLE
Fix for bug in QR decomposition

### DIFF
--- a/amgcl/detail/qr.hpp
+++ b/amgcl/detail/qr.hpp
@@ -124,7 +124,7 @@ class QR {
         // Computes a QR factorization of the matrix A, where Q is represented
         // as a product of elementary reflectors.
         //     Q = H(1) H(2) . . . H(k), where k = min(rows,cols).
-        void compute(int rows, int cols, value_type *A, int max_cols = -1) {
+        void compute(int rows, int cols, int row_stride, int col_stride, value_type *A, int max_cols = -1) {
             /*
              *  Ported from ZGEQR2
              *  ==================
@@ -174,9 +174,6 @@ class QR {
 
             if (k <= 0) return;
 
-            const int row_stride = (Order == row_major ? nmax : 1);
-            const int col_stride = (Order == row_major ? 1 : m);
-
             for(int i = 0, ii = 0; i < k; ++i, ii += row_stride + col_stride) {
                 // Generate elementary reflector H(i) to annihilate A[i+1:m)[i]
                 tau[i] = gen_reflector(m-i, A[ii], A + ii + row_stride, row_stride);
@@ -192,8 +189,21 @@ class QR {
         // Performs explicit factorization of the matrix A.
         // Calls compute() and explicitly forms factors Q and R,
         // so that Q() and R() methods below are valid calls.
-        void factorize(int rows, int cols, int row_stride, int col_stride, value_type *A) {
-            // ...
+        void factorize(int rows, int cols, int row_stride, int col_stride, value_type *A, int max_cols = -1) {
+            compute(rows, cols, row_stride, col_stride, A, max_cols);
+            compute_q(max_cols);
+        }
+
+        // Convenience wrappers where row_stride and col_stride are determined automatically.
+        void factorize(int rows, int cols, value_type *A, int max_cols = -1) {
+            int m = rows;
+            int n = cols;
+            int nmax = (max_cols < 0 ? n : max_cols);
+
+            const int row_stride = (Order == row_major ? nmax : 1);
+            const int col_stride = (Order == row_major ? 1 : m);
+
+            factorize(rows, cols, row_stride, col_stride, A, max_cols);
         }
 
         void append_cols(int cols) {
@@ -244,22 +254,47 @@ class QR {
         // Solve over- or underdetermined system Ax = rhs.
         // Calls compute() on the appropriate version of A (either transposed
         // or not).
-        void solve(value_type *f, value_type *x) const {
+        void solve(int rows, int cols, value_type *A, value_type *rhs, value_type *x) {
             const int row_stride = (Order == row_major ? nmax : 1);
             const int col_stride = (Order == row_major ? 1 : m);
 
-            for(int i = 0, ii = 0; i < n; ++i, ii += row_stride + col_stride)
-                apply_reflector(m-i, 1, r+ii, row_stride, math::adjoint(tau[i]), f+i, 1, 1);
+            if (rows >= cols) {
 
-            std::copy(f, f+n, x);
+                compute(rows, cols, row_stride, col_stride, A);
 
-            for(int i = n; i --> 0; ) {
-                value_type rii = r[i*(row_stride+col_stride)];
-                if (math::is_zero(rii)) continue;
-                x[i] = math::inverse(rii) * x[i];
+                for(int i = 0, ii = 0; i < n; ++i, ii += row_stride + col_stride)
+                    apply_reflector(m-i, 1, r+ii, row_stride, math::adjoint(tau[i]), rhs+i, 1, 1);
 
-                for(int j = 0, ja = 0; j < i; ++j, ja += row_stride)
-                    x[j] -= r[ja+i*col_stride] * x[i];
+                std::copy(rhs, rhs+n, x);
+
+                for(int i = n; i --> 0; ) {
+                    value_type rii = r[i*(row_stride+col_stride)];
+                    if (math::is_zero(rii)) continue;
+                    x[i] = math::inverse(rii) * x[i];
+
+                    for(int j = 0, ja = 0; j < i; ++j, ja += row_stride)
+                        x[j] -= r[ja+i*col_stride] * x[i];
+                }
+
+            } else {
+
+                compute(cols, rows, col_stride, row_stride, A);
+
+                for(int i = 0; i < n; ++i) {
+                    value_type rii = math::adjoint(r[i*(row_stride+col_stride)]);
+                    if (math::is_zero(rii)) continue;
+
+                    for(int j = 0, ja = 0; j < i; ++j, ja += row_stride)
+                        rhs[i] -= math::adjoint(r[ja+i*col_stride]) * rhs[j];
+
+                    rhs[i] *= math::inverse(rii);
+                }
+
+                std::copy(rhs, rhs+n, x);
+
+                for(int i = 0, ii = 0; i < m; ++i, ii += row_stride + col_stride)
+                    apply_reflector(m-i, 1, r+ii, row_stride, math::adjoint(tau[i]), x+i, 1, 1);
+
             }
         }
 
@@ -460,7 +495,10 @@ class QR<value_type, Order, typename boost::enable_if< math::is_static_matrix<va
 
         QR() {}
 
-        void compute(int rows, int cols, value_type *A, int max_cols = -1) {
+        // Computes a QR factorization of the matrix A, where Q is represented
+        // as a product of elementary reflectors.
+        //     Q = H(1) H(2) . . . H(k), where k = min(rows,cols).
+        void compute(int rows, int cols, int row_stride, int col_stride, value_type *A, int max_cols = -1) {
             const int M = math::static_rows<value_type>::value;
             const int N = math::static_cols<value_type>::value;
 
@@ -473,8 +511,6 @@ class QR<value_type, Order, typename boost::enable_if< math::is_static_matrix<va
             buf.resize(M * m * N * nmax);
 
             const int brows = M * m;
-            const int row_stride = (Order == row_major ? nmax : 1);
-            const int col_stride = (Order == row_major ? 1 : m);
 
             for(int i = 0, ib = 0; i < m; ++i)
                 for(int ii = 0; ii < M; ++ii, ++ib)
@@ -482,7 +518,26 @@ class QR<value_type, Order, typename boost::enable_if< math::is_static_matrix<va
                         for(int jj = 0; jj < N; ++jj, jb += brows)
                             buf[ib + jb] = A[i * row_stride + j * col_stride](ii, jj);
 
-            base.compute(rows * M, cols * N, buf.data(), nmax * N);
+            base.compute(rows * M, cols * N, 1, m * M, buf.data(), nmax * N);
+        }
+
+        // Performs explicit factorization of the matrix A.
+        // Calls compute() and explicitly forms factors Q and R,
+        // so that Q() and R() methods below are valid calls.
+        void factorize(int rows, int cols, int row_stride, int col_stride, value_type *A) {
+            compute(rows, cols, row_stride, col_stride, A);
+            compute_q();
+        }
+
+        // Convenience wrappers where row_stride and col_stride are determined automatically.
+        void factorize(int rows, int cols, value_type *A) {
+            m = rows;
+            n = cols;
+
+            const int row_stride = (Order == row_major ? n : 1);
+            const int col_stride = (Order == row_major ? 1 : m);
+
+            factorize(rows, cols, row_stride, col_stride, A);
         }
 
         void append_cols(int cols) {
@@ -536,10 +591,15 @@ class QR<value_type, Order, typename boost::enable_if< math::is_static_matrix<va
             return v;
         }
 
-        // Solves the system Q R x = f
-        void solve(rhs_type *f, rhs_type *x) const {
+        // Solve over- or underdetermined system Ax = rhs.
+        // Calls compute() on the appropriate version of A (either transposed
+        // or not).
+        void solve(int rows, int cols, value_type *A, rhs_type *rhs, rhs_type *x) {
             base.solve(
-                    reinterpret_cast<scalar_type*>(f),
+                    rows,
+                    cols,
+                    A,
+                    reinterpret_cast<scalar_type*>(rhs),
                     reinterpret_cast<scalar_type*>(x)
                     );
         }

--- a/amgcl/detail/qr.hpp
+++ b/amgcl/detail/qr.hpp
@@ -121,6 +121,9 @@ class QR {
     public:
         QR() : m(0), n(0) {}
 
+        // Computes a QR factorization of the matrix A, where Q is represented
+        // as a product of elementary reflectors.
+        //     Q = H(1) H(2) . . . H(k), where k = min(rows,cols).
         void compute(int rows, int cols, value_type *A, int max_cols = -1) {
             /*
              *  Ported from ZGEQR2
@@ -186,6 +189,13 @@ class QR {
             }
         }
 
+        // Performs explicit factorization of the matrix A.
+        // Calls compute() and explicitly forms factors Q and R,
+        // so that Q() and R() methods below are valid calls.
+        void factorize(int rows, int cols, int row_stride, int col_stride, value_type *A) {
+            // ...
+        }
+
         void append_cols(int cols) {
             const int row_stride = (Order == row_major ? nmax : 1);
             const int col_stride = (Order == row_major ? 1 : m);
@@ -231,7 +241,9 @@ class QR {
             return q[i*row_stride + j*col_stride];
         }
 
-        // Solves the system Q R x = f
+        // Solve over- or underdetermined system Ax = rhs.
+        // Calls compute() on the appropriate version of A (either transposed
+        // or not).
         void solve(value_type *f, value_type *x) const {
             const int row_stride = (Order == row_major ? nmax : 1);
             const int col_stride = (Order == row_major ? 1 : m);

--- a/tests/test_qr.cpp
+++ b/tests/test_qr.cpp
@@ -78,6 +78,9 @@ void run_qr_test(const size_t n, const size_t m) {
         }
     }
 
+    // Keep in mind it's inplace computation.
+    A = A0;
+
     // Check that solution works (A^t A x == A^t f).
     typedef typename amgcl::math::rhs_of<value_type>::type rhs_type;
     std::vector<rhs_type> f0(n, amgcl::math::constant<rhs_type>(1));

--- a/tests/test_qr.cpp
+++ b/tests/test_qr.cpp
@@ -45,9 +45,7 @@ struct make_random< amgcl::static_matrix<T,N,M> > {
 };
 
 template <class value_type, amgcl::detail::storage_order order>
-void run_qr_test() {
-    const size_t n = 5;
-    const size_t m = 3;
+void run_qr_test(const size_t n, const size_t m) {
 
     typedef typename boost::conditional<order == amgcl::detail::row_major,
             boost::c_storage_order,
@@ -64,8 +62,7 @@ void run_qr_test() {
 
     amgcl::detail::QR<value_type, order> qr;
 
-    qr.compute(n, m, A.data());
-    qr.compute_q();
+    qr.factorize(n, m, A.data());
 
     // Check that A = QR
     for(size_t i = 0; i < n; ++i) {
@@ -88,7 +85,7 @@ void run_qr_test() {
 
     std::vector<rhs_type> x(m);
 
-    qr.solve(f.data(), x.data());
+    qr.solve(n, m, A.data(), f.data(), x.data());
 
     std::vector<rhs_type> Ax(n);
     for(size_t i = 0; i < n; ++i) {
@@ -117,12 +114,19 @@ void run_qr_test() {
 BOOST_AUTO_TEST_SUITE( test_qr )
 
 BOOST_AUTO_TEST_CASE( test_qr ) {
-    run_qr_test< double,                             amgcl::detail::row_major>();
-    run_qr_test< double,                             amgcl::detail::col_major>();
-    run_qr_test< std::complex<double>,               amgcl::detail::row_major>();
-    run_qr_test< std::complex<double>,               amgcl::detail::col_major>();
-    run_qr_test< amgcl::static_matrix<double, 2, 2>, amgcl::detail::row_major>();
-    run_qr_test< amgcl::static_matrix<double, 2, 2>, amgcl::detail::col_major>();
+    run_qr_test< double,                             amgcl::detail::row_major>(5, 3);
+    run_qr_test< double,                             amgcl::detail::col_major>(5, 3);
+    run_qr_test< std::complex<double>,               amgcl::detail::row_major>(5, 3);
+    run_qr_test< std::complex<double>,               amgcl::detail::col_major>(5, 3);
+    run_qr_test< amgcl::static_matrix<double, 2, 2>, amgcl::detail::row_major>(5, 3);
+    run_qr_test< amgcl::static_matrix<double, 2, 2>, amgcl::detail::col_major>(5, 3);
+
+    run_qr_test< double,                             amgcl::detail::row_major>(3, 5);
+    run_qr_test< double,                             amgcl::detail::col_major>(3, 5);
+    run_qr_test< std::complex<double>,               amgcl::detail::row_major>(3, 5);
+    run_qr_test< std::complex<double>,               amgcl::detail::col_major>(3, 5);
+    run_qr_test< amgcl::static_matrix<double, 2, 2>, amgcl::detail::row_major>(3, 5);
+    run_qr_test< amgcl::static_matrix<double, 2, 2>, amgcl::detail::col_major>(3, 5);
 }
 
 BOOST_AUTO_TEST_CASE( qr_issue_39 ) {
@@ -136,8 +140,7 @@ BOOST_AUTO_TEST_CASE( qr_issue_39 ) {
 
     amgcl::detail::QR<double, amgcl::detail::row_major> qr;
 
-    qr.compute(2, 2, A.data());
-    qr.compute_q();
+    qr.factorize(2, 2, A.data());
 
     // Check that A = QR
     for(int i = 0; i < 2; ++i) {


### PR DESCRIPTION
There seems to to be a small issue in the QR code for the case where rows < cols, where the loop in the solve function runs beyond the end of the rhs vector. I have modified the QR test case which shows the problem. Tried to fix it by using the correct value for the upper limit of the index.