### PR TITLE
Allow iterative solvers to exit on absolute error

### DIFF
--- a/amgcl/solver/bicgstab.hpp
+++ b/amgcl/solver/bicgstab.hpp
@@ -70,23 +70,29 @@ class bicgstab {
             /// Maximum number of iterations.
             size_t maxiter;
 
-            /// Target residual error.
+            /// Target relative residual error.
             scalar_type tol;
 
+            /// Target absolute residual error.
+            scalar_type abstol;
+
             params(size_t maxiter = 100, scalar_type tol = 1e-8)
-                : maxiter(maxiter), tol(tol)
+                : maxiter(maxiter), tol(tol),
+                  abstol(std::numeric_limits<scalar_type>::min())
             {}
 
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, maxiter),
-                  AMGCL_PARAMS_IMPORT_VALUE(p, tol)
+                  AMGCL_PARAMS_IMPORT_VALUE(p, tol),
+                  AMGCL_PARAMS_IMPORT_VALUE(p, abstol)
             {
-                AMGCL_PARAMS_CHECK(p, (maxiter)(tol));
+                AMGCL_PARAMS_CHECK(p, (maxiter)(tol)(abstol));
             }
 
             void get(boost::property_tree::ptree &p, const std::string &path) const {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, maxiter);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, tol);
+                AMGCL_PARAMS_EXPORT_VALUE(p, path, abstol);
             }
         };
 
@@ -144,7 +150,7 @@ class bicgstab {
                 return boost::make_tuple(0, norm_rhs);
             }
 
-            scalar_type eps = norm_rhs * prm.tol;
+            scalar_type eps = std::max(norm_rhs * prm.tol, prm.abstol);
 
             coef_type rho1  = zero;
             coef_type rho2  = zero;

--- a/amgcl/solver/cg.hpp
+++ b/amgcl/solver/cg.hpp
@@ -81,23 +81,29 @@ class cg {
             /// Maximum number of iterations.
             size_t maxiter;
 
-            /// Target residual error.
+            /// Target relative residual error.
             scalar_type tol;
 
+            /// Target absolute residual error.
+            scalar_type abstol;
+
             params(size_t maxiter = 100, scalar_type tol = 1e-8)
-                : maxiter(maxiter), tol(tol)
+                : maxiter(maxiter), tol(tol),
+                  abstol(std::numeric_limits<scalar_type>::min())
             {}
 
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, maxiter),
-                  AMGCL_PARAMS_IMPORT_VALUE(p, tol)
+                  AMGCL_PARAMS_IMPORT_VALUE(p, tol),
+                  AMGCL_PARAMS_IMPORT_VALUE(p, abstol)
             {
-                AMGCL_PARAMS_CHECK(p, (maxiter)(tol));
+                AMGCL_PARAMS_CHECK(p, (maxiter)(tol)(abstol));
             }
 
             void get(boost::property_tree::ptree &p, const std::string &path) const {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, maxiter);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, tol);
+                AMGCL_PARAMS_EXPORT_VALUE(p, path, abstol);
             }
         };
 
@@ -149,7 +155,7 @@ class cg {
                 return boost::make_tuple(0, norm_rhs);
             }
 
-            scalar_type eps  = prm.tol * norm_rhs;
+            scalar_type eps  = std::max(prm.tol * norm_rhs, prm.abstol);
 
             coef_type rho1 = 2 * eps * one;
             coef_type rho2 = zero;

--- a/amgcl/solver/gmres.hpp
+++ b/amgcl/solver/gmres.hpp
@@ -76,25 +76,31 @@ class gmres {
             /// Maximum number of iterations.
             unsigned maxiter;
 
-            /// Target residual error.
+            /// Target relative residual error.
             scalar_type tol;
 
+            /// Target absolute residual error.
+            scalar_type abstol;
+
             params(unsigned M = 30, unsigned maxiter = 100, scalar_type tol = 1e-8)
-                : M(M), maxiter(maxiter), tol(tol)
+                : M(M), maxiter(maxiter), tol(tol),
+                  abstol(std::numeric_limits<scalar_type>::min())
             { }
 
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, M),
                   AMGCL_PARAMS_IMPORT_VALUE(p, maxiter),
-                  AMGCL_PARAMS_IMPORT_VALUE(p, tol)
+                  AMGCL_PARAMS_IMPORT_VALUE(p, tol),
+                  AMGCL_PARAMS_IMPORT_VALUE(p, abstol)
             {
-                AMGCL_PARAMS_CHECK(p, (M)(maxiter)(tol));
+                AMGCL_PARAMS_CHECK(p, (M)(maxiter)(tol)(abstol));
             }
 
             void get(boost::property_tree::ptree &p, const std::string &path) const {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, M);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, maxiter);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, tol);
+                AMGCL_PARAMS_EXPORT_VALUE(p, path, abstol);
             }
         };
 
@@ -144,7 +150,8 @@ class gmres {
                 return boost::make_tuple(0, norm_rhs);
             }
 
-            scalar_type eps = prm.tol * norm_rhs, norm_r = math::zero<scalar_type>();
+            scalar_type eps = std::max(prm.tol * norm_rhs, prm.abstol);
+            scalar_type norm_r = math::zero<scalar_type>();
 
             while(true) {
                 backend::residual(rhs, A, x, *r);


### PR DESCRIPTION
By default the absolute tolerance is set to [`std::numeric_limits<T>::min()`](http://en.cppreference.com/w/cpp/types/numeric_limits/min), so that the default solver behavior stays the same. One can set the value of `abstol` when exit on absolute residual value is required.

See #37. 

@Andlon, could you please check if this works for you?