### PR TITLE
Allow to reduce compilation overhead

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ configuration:
     - Release
 build_script:
     - git submodule update --init --recursive
-    - cmake -DAMGCL_BUILD_TESTS=ON -DAMGCL_BUILD_EXAMPLES=ON . -Bbuild
+    - cmake -DAMGCL_BUILD_TESTS=ON -DAMGCL_BUILD_EXAMPLES=ON -DAMGCL_DISABLE_RARE_COMPONENTS=ON . -Bbuild
     - cmake --build build --config Release
 test_script:
     - cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,16 @@ endif()
 if (AMGCL_MASTER_PROJECT)
     option(AMGCL_BUILD_TESTS    OFF)
     option(AMGCL_BUILD_EXAMPLES OFF)
+    option(AMGCL_DISABLE_RARE_COMPONENTS OFF)
+
+    if(AMGCL_DISABLE_RARE_COMPONENTS)
+        add_definitions(
+            -DAMGCL_RUNTIME_DISABLE_MULTICOLOR_GS
+            -DAMGCL_RUNTIME_DISABLE_PARALLEL_ILU0
+            -DAMGCL_RUNTIME_DISABLE_SPAI1
+            -DAMGCL_RUNTIME_DISABLE_CHEBYSHEV
+            )
+    endif()
 
     add_subdirectory(docs)
 

--- a/amgcl/relaxation/runtime.hpp
+++ b/amgcl/relaxation/runtime.hpp
@@ -94,10 +94,10 @@ inline std::istream& operator>>(std::istream &in, type &r)
     std::string val;
     in >> val;
 
-    if (val == "multicolor_gauss_seidel")
-        r = multicolor_gauss_seidel;
-    else if (val == "gauss_seidel")
+    if (val == "gauss_seidel")
         r = gauss_seidel;
+    else if (val == "multicolor_gauss_seidel")
+        r = multicolor_gauss_seidel;
     else if (val == "ilu0")
         r = ilu0;
     else if (val == "parallel_ilu0")
@@ -157,15 +157,19 @@ void process_rap(runtime::relaxation::type relaxation, const Func &func) {
         case runtime::relaxation::gauss_seidel:
             process_rap<Backend, amgcl::relaxation::gauss_seidel>(func);
             break;
+#ifndef AMGCL_RUNTIME_DISABLE_MULTICOLOR_GS
         case runtime::relaxation::multicolor_gauss_seidel:
             process_rap<Backend, amgcl::relaxation::multicolor_gauss_seidel>(func);
             break;
+#endif
         case runtime::relaxation::ilu0:
             process_rap<Backend, amgcl::relaxation::ilu0>(func);
             break;
+#ifndef AMGCL_RUNTIME_DISABLE_PARALLEL_ILU0
         case runtime::relaxation::parallel_ilu0:
             process_rap<Backend, amgcl::relaxation::parallel_ilu0>(func);
             break;
+#endif
         case runtime::relaxation::iluk:
             process_rap<Backend, amgcl::relaxation::iluk>(func);
             break;
@@ -178,12 +182,18 @@ void process_rap(runtime::relaxation::type relaxation, const Func &func) {
         case runtime::relaxation::spai0:
             process_rap<Backend, amgcl::relaxation::spai0>(func);
             break;
+#ifndef AMGCL_RUNTIME_DISABLE_SPAI1
         case runtime::relaxation::spai1:
             process_rap<Backend, amgcl::relaxation::spai1>(func);
             break;
+#endif
+#ifndef AMGCL_RUNTIME_DISABLE_CHEBYSHEV
         case runtime::relaxation::chebyshev:
             process_rap<Backend, amgcl::relaxation::chebyshev>(func);
             break;
+#endif
+        default:
+            precondition(false, "Unsupported relaxation value");
     }
 }
 

--- a/amgcl/runtime.hpp
+++ b/amgcl/runtime.hpp
@@ -179,6 +179,7 @@ process_amg(
                 amgcl::relaxation::gauss_seidel
                 >(func);
             break;
+#ifndef AMGCL_RUNTIME_DISABLE_MULTICOLOR_GS
         case runtime::relaxation::multicolor_gauss_seidel:
             process_amg<
                 Backend,
@@ -186,6 +187,7 @@ process_amg(
                 amgcl::relaxation::multicolor_gauss_seidel
                 >(func);
             break;
+#endif
         case runtime::relaxation::ilu0:
             process_amg<
                 Backend,
@@ -193,6 +195,7 @@ process_amg(
                 amgcl::relaxation::ilu0
                 >(func);
             break;
+#ifndef AMGCL_RUNTIME_DISABLE_PARALLEL_ILU0
         case runtime::relaxation::parallel_ilu0:
             process_amg<
                 Backend,
@@ -200,6 +203,7 @@ process_amg(
                 amgcl::relaxation::parallel_ilu0
                 >(func);
             break;
+#endif
         case runtime::relaxation::iluk:
             process_amg<
                 Backend,
@@ -228,6 +232,7 @@ process_amg(
                 amgcl::relaxation::spai0
                 >(func);
             break;
+#ifndef AMGCL_RUNTIME_DISABLE_SPAI1
         case runtime::relaxation::spai1:
             process_amg<
                 Backend,
@@ -235,6 +240,8 @@ process_amg(
                 amgcl::relaxation::spai1
                 >(func);
             break;
+#endif
+#ifndef AMGCL_RUNTIME_DISABLE_CHEBYSHEV
         case runtime::relaxation::chebyshev:
             process_amg<
                 Backend,
@@ -242,6 +249,9 @@ process_amg(
                 amgcl::relaxation::chebyshev
                 >(func);
             break;
+#endif
+        default:
+            precondition(false, "Unsupported relaxation value");
     }
 }
 

--- a/tests/test_solver.hpp
+++ b/tests/test_solver.hpp
@@ -105,16 +105,24 @@ void test_problem(
     };
 
     amgcl::runtime::relaxation::type relaxation[] = {
-        amgcl::runtime::relaxation::spai0,
-        amgcl::runtime::relaxation::spai1,
-        amgcl::runtime::relaxation::damped_jacobi,
-        amgcl::runtime::relaxation::gauss_seidel,
-        amgcl::runtime::relaxation::multicolor_gauss_seidel,
-        amgcl::runtime::relaxation::ilu0,
-        amgcl::runtime::relaxation::parallel_ilu0,
-        amgcl::runtime::relaxation::iluk,
-        amgcl::runtime::relaxation::ilut,
-        amgcl::runtime::relaxation::chebyshev
+        amgcl::runtime::relaxation::spai0
+#ifndef AMGCL_RUNTIME_DISABLE_SPAI1
+      , amgcl::runtime::relaxation::spai1
+#endif
+      , amgcl::runtime::relaxation::damped_jacobi
+      , amgcl::runtime::relaxation::gauss_seidel
+#ifndef AMGCL_RUNTIME_DISABLE_MULTICOLOR_GS
+      , amgcl::runtime::relaxation::multicolor_gauss_seidel
+#endif
+      , amgcl::runtime::relaxation::ilu0
+#ifndef AMGCL_RUNTIME_DISABLE_PARALLEL_ILU0
+      , amgcl::runtime::relaxation::parallel_ilu0
+#endif
+      , amgcl::runtime::relaxation::iluk
+      , amgcl::runtime::relaxation::ilut
+#ifndef AMGCL_RUNTIME_DISABLE_CHEBYSHEV
+      , amgcl::runtime::relaxation::chebyshev
+#endif
     };
 
     amgcl::runtime::solver::type solver[] = {


### PR DESCRIPTION
 by disabling unused components in runtime interface. This should help with 'compiler is out of heap space' kinds of errors during compilation with MSVC.

For now it is possible to disable
* `multicolor_gauss_seidel`,
* `parallel_ilu0`,
* `spai1`, and
* `chebyshev`

relaxation types by correspondingly defining

* `AMGCL_RUNTIME_DISABLE_MULTICOLOR_GS`,
* `AMGCL_RUNTIME_DISABLE_PARALLEL_ILU0`,
* `AMGCL_RUNTIME_DISABLE_SPAI1`, and
* `AMGCL_RUNTIME_DISABLE_CHEBYSHEV`,

 preprocessor definitions.

CC @RiccardoRossi.