### PR TITLE
Bug with params initializer in vexcl.hpp

### DIFF
--- a/amgcl/backend/vexcl.hpp
+++ b/amgcl/backend/vexcl.hpp
@@ -111,7 +111,7 @@ struct vexcl {
         params() : fast_matrix_setup(true) {}
 
         params(const boost::property_tree::ptree &p)
-            : AMGCL_PARAMS_IMPORT_CHILD(p, fast_matrix_setup)
+            : AMGCL_PARAMS_IMPORT_VALUE(p, fast_matrix_setup)
         {
             std::vector<vex::backend::command_queue> *ptr = 0;
             ptr = p.get("q", ptr);


### PR DESCRIPTION
Causes compilation to fail on MacOS but curiously not on Linux. I believe the intention was to use the value of "fast_matrix_setup, rather than check a child ptree against a bool?