### PR TITLE
Fix redefinition of real for scalar in C++11

### DIFF
--- a/amgcl/solver/bicgstabl.hpp
+++ b/amgcl/solver/bicgstabl.hpp
@@ -75,10 +75,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <amgcl/util.hpp>
 
 // std::real is not overloaded for scalar arguments pre c++11:
+#ifndef BOOST_HAS_TR1_COMPLEX_OVERLOADS
 namespace std {
 inline float real(float x) { return x; }
 inline double real(double x) { return x; }
 }
+#endif
 
 namespace amgcl {
 namespace solver {


### PR DESCRIPTION
This should prevent the ambiguous declaration of real