### PR TITLE
Checking std::real against __cplusplus number

### DIFF
--- a/amgcl/solver/bicgstabl.hpp
+++ b/amgcl/solver/bicgstabl.hpp
@@ -75,7 +75,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <amgcl/util.hpp>
 
 // std::real is not overloaded for scalar arguments pre c++11:
-#ifndef BOOST_HAS_TR1_COMPLEX_OVERLOADS
+#if !defined(BOOST_HAS_TR1_COMPLEX_OVERLOADS) || __cplusplus <= 199711L
 namespace std {
 inline float real(float x) { return x; }
 inline double real(double x) { return x; }


### PR DESCRIPTION
Continuation of #68.
Some clang versions not using `libstdcpp3.hpp` header were still complaining.