### PR TITLE
Only use Boost.PropertyTree if runtime interface is used

### DIFF
--- a/amgcl/amg.hpp
+++ b/amgcl/amg.hpp
@@ -155,6 +155,7 @@ class amg {
 #endif
             {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, coarsening),
                   AMGCL_PARAMS_IMPORT_CHILD(p, relax),
@@ -196,6 +197,7 @@ class amg {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, async_setup);
 #endif
             }
+#endif
         } prm;
 
         /// Builds the AMG hierarchy for the system matrix.

--- a/amgcl/backend/block_crs.hpp
+++ b/amgcl/backend/block_crs.hpp
@@ -158,6 +158,8 @@ struct block_crs {
         size_t block_size;
 
         params(size_t block_size = 4) : block_size(block_size) {}
+
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, block_size)
         {
@@ -166,6 +168,7 @@ struct block_crs {
         void get(boost::property_tree::ptree &p, const std::string &path) const {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, block_size);
         }
+#endif
     };
 
     static std::string name() { return "block_crs"; }

--- a/amgcl/backend/cuda.hpp
+++ b/amgcl/backend/cuda.hpp
@@ -265,6 +265,7 @@ struct cuda {
 
         params(cusparseHandle_t handle = 0) : cusparse_handle(handle) {}
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, cusparse_handle)
         {
@@ -274,6 +275,7 @@ struct cuda {
         void get(boost::property_tree::ptree &p, const std::string &path) const {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, cusparse_handle);
         }
+#endif
     };
 
     static std::string name() { return "cuda"; }

--- a/amgcl/coarsening/aggregation.hpp
+++ b/amgcl/coarsening/aggregation.hpp
@@ -96,6 +96,7 @@ struct aggregation {
 
         params() : over_interp(1.5f) { }
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_CHILD(p, aggr),
               AMGCL_PARAMS_IMPORT_CHILD(p, nullspace),
@@ -109,6 +110,7 @@ struct aggregation {
             AMGCL_PARAMS_EXPORT_CHILD(p, path, nullspace);
             AMGCL_PARAMS_EXPORT_VALUE(p, path, over_interp);
         }
+#endif
     } prm;
 
     aggregation(const params &prm = params()) : prm(prm) {}

--- a/amgcl/coarsening/plain_aggregates.hpp
+++ b/amgcl/coarsening/plain_aggregates.hpp
@@ -74,6 +74,7 @@ struct plain_aggregates {
 
         params() : eps_strong(0.08f) {}
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, eps_strong)
         {
@@ -83,6 +84,7 @@ struct plain_aggregates {
         void get(boost::property_tree::ptree &p, const std::string &path) const {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, eps_strong);
         }
+#endif
     };
 
     static const ptrdiff_t undefined = -1;

--- a/amgcl/coarsening/pointwise_aggregates.hpp
+++ b/amgcl/coarsening/pointwise_aggregates.hpp
@@ -61,6 +61,7 @@ class pointwise_aggregates {
 
             params() : block_size(1) {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : plain_aggregates::params(p),
                   AMGCL_PARAMS_IMPORT_VALUE(p, block_size)
@@ -72,6 +73,7 @@ class pointwise_aggregates {
                 plain_aggregates::params::get(p, path);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, block_size);
             }
+#endif
         };
 
         static const ptrdiff_t undefined = -1;

--- a/amgcl/coarsening/ruge_stuben.hpp
+++ b/amgcl/coarsening/ruge_stuben.hpp
@@ -81,6 +81,7 @@ struct ruge_stuben {
 
         params() : eps_strong(0.25f), do_trunc(true), eps_trunc(0.2f) {}
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, eps_strong),
               AMGCL_PARAMS_IMPORT_VALUE(p, do_trunc),
@@ -94,6 +95,7 @@ struct ruge_stuben {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, do_trunc);
             AMGCL_PARAMS_EXPORT_VALUE(p, path, eps_trunc);
         }
+#endif
     } prm;
 
     ruge_stuben(const params &prm = params()) : prm(prm) {}

--- a/amgcl/coarsening/smoothed_aggr_emin.hpp
+++ b/amgcl/coarsening/smoothed_aggr_emin.hpp
@@ -65,6 +65,7 @@ struct smoothed_aggr_emin {
 
         params() {}
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_CHILD(p, aggr),
               AMGCL_PARAMS_IMPORT_CHILD(p, nullspace)
@@ -76,6 +77,7 @@ struct smoothed_aggr_emin {
             AMGCL_PARAMS_EXPORT_CHILD(p, path, aggr);
             AMGCL_PARAMS_EXPORT_CHILD(p, path, nullspace);
         }
+#endif
     } prm;
 
     smoothed_aggr_emin(const params &prm = params()) : prm(prm) {}

--- a/amgcl/coarsening/smoothed_aggregation.hpp
+++ b/amgcl/coarsening/smoothed_aggregation.hpp
@@ -103,6 +103,7 @@ struct smoothed_aggregation {
 
         params() : relax(1.0f), estimate_spectral_radius(false), power_iters(0) { }
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_CHILD(p, aggr),
               AMGCL_PARAMS_IMPORT_CHILD(p, nullspace),
@@ -120,6 +121,7 @@ struct smoothed_aggregation {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, estimate_spectral_radius);
             AMGCL_PARAMS_EXPORT_VALUE(p, path, power_iters);
         }
+#endif
     } prm;
 
     smoothed_aggregation(const params &prm = params()) : prm(prm) {}

--- a/amgcl/coarsening/tentative_prolongation.hpp
+++ b/amgcl/coarsening/tentative_prolongation.hpp
@@ -73,6 +73,7 @@ struct nullspace_params {
 
     nullspace_params() : cols(0) {}
 
+#ifdef BOOST_VERSION
     nullspace_params(const boost::property_tree::ptree &p)
         : cols(p.get("cols", nullspace_params().cols))
     {
@@ -105,6 +106,7 @@ struct nullspace_params {
     }
 
     void get(boost::property_tree::ptree&, const std::string&) const {}
+#endif
 };
 
 /// Tentative prolongation operator

--- a/amgcl/make_solver.hpp
+++ b/amgcl/make_solver.hpp
@@ -69,6 +69,7 @@ class make_solver {
 
             params() {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, precond),
                   AMGCL_PARAMS_IMPORT_CHILD(p, solver)
@@ -83,6 +84,7 @@ class make_solver {
                 AMGCL_PARAMS_EXPORT_CHILD(p, path, precond);
                 AMGCL_PARAMS_EXPORT_CHILD(p, path, solver);
             }
+#endif
         } prm;
 
         /** Sets up the preconditioner and creates the iterative solver. */
@@ -189,10 +191,12 @@ class make_solver {
             return P.system_matrix();
         }
 
+#ifdef BOOST_VERSION
         /// Stores the parameters used during construction into the property tree \p p.
         void get_params(boost::property_tree::ptree &p) const {
             prm.get(p);
         }
+#endif
 
         /// Returns the size of the system matrix.
         size_t size() const {

--- a/amgcl/mpi/amg.hpp
+++ b/amgcl/mpi/amg.hpp
@@ -113,6 +113,7 @@ class amg {
                 npre(1), npost(1), ncycle(1), pre_cycles(1)
             {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, coarsening),
                   AMGCL_PARAMS_IMPORT_CHILD(p, relax),
@@ -148,6 +149,7 @@ class amg {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, ncycle);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, pre_cycles);
             }
+#endif
         } prm;
 
         template <class Matrix>

--- a/amgcl/mpi/coarsening/aggregation.hpp
+++ b/amgcl/mpi/coarsening/aggregation.hpp
@@ -73,6 +73,7 @@ struct aggregation {
 
         params() : over_interp(1.5f) { }
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_CHILD(p, aggr),
               AMGCL_PARAMS_IMPORT_VALUE(p, over_interp)
@@ -84,6 +85,7 @@ struct aggregation {
             AMGCL_PARAMS_EXPORT_CHILD(p, path, aggr);
             AMGCL_PARAMS_EXPORT_VALUE(p, path, over_interp);
         }
+#endif
     } prm;
 
     aggregation(const params &prm = params()) : prm(prm) {}

--- a/amgcl/mpi/coarsening/pmis.hpp
+++ b/amgcl/mpi/coarsening/pmis.hpp
@@ -63,6 +63,7 @@ struct pmis {
 
         params() : eps_strong(0.08), block_size(1) { }
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, eps_strong),
               AMGCL_PARAMS_IMPORT_VALUE(p, block_size)
@@ -74,6 +75,7 @@ struct pmis {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, eps_strong);
             AMGCL_PARAMS_EXPORT_VALUE(p, path, block_size);
         }
+#endif
     };
 
     std::shared_ptr< distributed_matrix<bool_backend> > conn;

--- a/amgcl/mpi/coarsening/runtime.hpp
+++ b/amgcl/mpi/coarsening/runtime.hpp
@@ -31,6 +31,8 @@ THE SOFTWARE.
  * \brief  Runtime wrapper for distributed coarsening schemes.
  */
 
+#include <boost/property_tree/ptree.hpp>
+
 #include <amgcl/util.hpp>
 #include <amgcl/mpi/util.hpp>
 #include <amgcl/mpi/distributed_matrix.hpp>

--- a/amgcl/mpi/coarsening/smoothed_aggregation.hpp
+++ b/amgcl/mpi/coarsening/smoothed_aggregation.hpp
@@ -72,6 +72,7 @@ struct smoothed_aggregation {
             : relax(1.0f), estimate_spectral_radius(false), power_iters(0)
         { }
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_CHILD(p, aggr),
               AMGCL_PARAMS_IMPORT_VALUE(p, relax),
@@ -87,6 +88,7 @@ struct smoothed_aggregation {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, estimate_spectral_radius);
             AMGCL_PARAMS_EXPORT_VALUE(p, path, power_iters);
         }
+#endif
     } prm;
 
     smoothed_aggregation(const params &prm = params()) : prm(prm) {}

--- a/amgcl/mpi/direct_solver/pastix.hpp
+++ b/amgcl/mpi/direct_solver/pastix.hpp
@@ -74,6 +74,7 @@ class pastix : public solver_base< value_type, pastix<value_type, Distrib> > {
                 : max_rows_per_process(50000)
             {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, max_rows_per_process)
             {
@@ -83,6 +84,7 @@ class pastix : public solver_base< value_type, pastix<value_type, Distrib> > {
             void get(boost::property_tree::ptree &p, const std::string &path) const {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, max_rows_per_process);
             }
+#endif
         };
 
         /// Constructor.

--- a/amgcl/mpi/direct_solver/runtime.hpp
+++ b/amgcl/mpi/direct_solver/runtime.hpp
@@ -31,6 +31,8 @@ THE SOFTWARE.
  * \brief  Runtime wrapper for distributed direct solvers.
  */
 
+#include <boost/property_tree/ptree.hpp>
+
 #include <amgcl/util.hpp>
 #include <amgcl/mpi/direct_solver/skyline_lu.hpp>
 #ifdef AMGCL_HAVE_EIGEN

--- a/amgcl/mpi/make_solver.hpp
+++ b/amgcl/mpi/make_solver.hpp
@@ -66,6 +66,7 @@ class make_solver {
 
             params() {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, precond),
                   AMGCL_PARAMS_IMPORT_CHILD(p, solver)
@@ -78,6 +79,7 @@ class make_solver {
                 AMGCL_PARAMS_EXPORT_CHILD(p, path, precond);
                 AMGCL_PARAMS_EXPORT_CHILD(p, path, solver);
             }
+#endif
         } prm;
 
         template <class Matrix>
@@ -146,9 +148,11 @@ class make_solver {
             return P.system_matrix();
         }
 
+#ifdef BOOST_VERSION
         void get_params(boost::property_tree::ptree &p) const {
             prm.get(p);
         }
+#endif
 
         size_t size() const {
             return n;

--- a/amgcl/mpi/partition/merge.hpp
+++ b/amgcl/mpi/partition/merge.hpp
@@ -57,6 +57,7 @@ struct merge {
             enable(false), min_per_proc(10000), shrink_ratio(8)
         {}
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, enable),
               AMGCL_PARAMS_IMPORT_VALUE(p, min_per_proc),
@@ -74,6 +75,7 @@ struct merge {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, min_per_proc);
             AMGCL_PARAMS_EXPORT_VALUE(p, path, shrink_ratio);
         }
+#endif
     } prm;
 
     merge(const params &prm = params()) : prm(prm) {}

--- a/amgcl/mpi/partition/parmetis.hpp
+++ b/amgcl/mpi/partition/parmetis.hpp
@@ -59,6 +59,7 @@ struct parmetis {
             enable(false), min_per_proc(10000), shrink_ratio(8)
         {}
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, enable),
               AMGCL_PARAMS_IMPORT_VALUE(p, min_per_proc),
@@ -76,6 +77,7 @@ struct parmetis {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, min_per_proc);
             AMGCL_PARAMS_EXPORT_VALUE(p, path, shrink_ratio);
         }
+#endif
     } prm;
 
     parmetis(const params &prm = params()) : prm(prm) {}

--- a/amgcl/mpi/partition/ptscotch.hpp
+++ b/amgcl/mpi/partition/ptscotch.hpp
@@ -59,6 +59,7 @@ struct ptscotch {
             enable(false), min_per_proc(10000), shrink_ratio(8)
         {}
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, enable),
               AMGCL_PARAMS_IMPORT_VALUE(p, min_per_proc),
@@ -76,6 +77,7 @@ struct ptscotch {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, min_per_proc);
             AMGCL_PARAMS_EXPORT_VALUE(p, path, shrink_ratio);
         }
+#endif
     } prm;
 
     ptscotch(const params &prm = params()) : prm(prm) {}

--- a/amgcl/mpi/partition/runtime.hpp
+++ b/amgcl/mpi/partition/runtime.hpp
@@ -32,6 +32,7 @@ THE SOFTWARE.
  */
 
 #include <memory>
+#include <boost/property_tree/ptree.hpp>
 
 #include <amgcl/mpi/partition/merge.hpp>
 

--- a/amgcl/mpi/relaxation/runtime.hpp
+++ b/amgcl/mpi/relaxation/runtime.hpp
@@ -32,6 +32,9 @@ THE SOFTWARE.
  */
 
 #include <memory>
+
+#include <boost/property_tree/ptree.hpp>
+
 #include <amgcl/backend/interface.hpp>
 #include <amgcl/value_type/interface.hpp>
 #include <amgcl/relaxation/runtime.hpp>

--- a/amgcl/mpi/schur_pressure_correction.hpp
+++ b/amgcl/mpi/schur_pressure_correction.hpp
@@ -81,6 +81,7 @@ class schur_pressure_correction {
 
             params() : approx_schur(true) {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, usolver),
                   AMGCL_PARAMS_IMPORT_CHILD(p, psolver),
@@ -142,6 +143,7 @@ class schur_pressure_correction {
                 AMGCL_PARAMS_EXPORT_CHILD(p, path, psolver);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, approx_schur);
             }
+#endif
         } prm;
 
         template <class Matrix>

--- a/amgcl/mpi/subdomain_deflation.hpp
+++ b/amgcl/mpi/subdomain_deflation.hpp
@@ -129,6 +129,7 @@ class subdomain_deflation {
 
             params() {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, local),
                   AMGCL_PARAMS_IMPORT_CHILD(p, isolver),
@@ -153,6 +154,7 @@ class subdomain_deflation {
                 AMGCL_PARAMS_EXPORT_CHILD(p, path, dsolver);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, num_def_vec);
             }
+#endif
         };
 
         typedef typename backend_type::value_type value_type;

--- a/amgcl/preconditioner/cpr.hpp
+++ b/amgcl/preconditioner/cpr.hpp
@@ -71,6 +71,7 @@ class cpr {
 
             params() : block_size(2), active_rows(0) {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, pprecond),
                   AMGCL_PARAMS_IMPORT_CHILD(p, sprecond),
@@ -87,6 +88,7 @@ class cpr {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, block_size);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, active_rows);
             }
+#endif
         } prm;
 
         template <class Matrix>

--- a/amgcl/preconditioner/cpr_drs.hpp
+++ b/amgcl/preconditioner/cpr_drs.hpp
@@ -77,6 +77,7 @@ class cpr_drs {
 
             params() : block_size(2), active_rows(0), eps_dd(0.2), eps_ps(0.02) {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, pprecond),
                   AMGCL_PARAMS_IMPORT_CHILD(p, sprecond),
@@ -114,6 +115,7 @@ class cpr_drs {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, eps_dd);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, eps_ps);
             }
+#endif
         } prm;
 
         template <class Matrix>

--- a/amgcl/preconditioner/schur_pressure_correction.hpp
+++ b/amgcl/preconditioner/schur_pressure_correction.hpp
@@ -121,6 +121,7 @@ class schur_pressure_correction {
 
             params() : approx_schur(true) {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, usolver),
                   AMGCL_PARAMS_IMPORT_CHILD(p, psolver),
@@ -182,6 +183,7 @@ class schur_pressure_correction {
                 AMGCL_PARAMS_EXPORT_CHILD(p, path, psolver);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, approx_schur);
             }
+#endif
         } prm;
 
         template <class Matrix>

--- a/amgcl/relaxation/chebyshev.hpp
+++ b/amgcl/relaxation/chebyshev.hpp
@@ -68,6 +68,7 @@ class chebyshev {
 
             params() : degree(5), lower(1.0f / 30), power_iters(0) {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, degree),
                   AMGCL_PARAMS_IMPORT_VALUE(p, lower),
@@ -81,6 +82,7 @@ class chebyshev {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, lower);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, power_iters);
             }
+#endif
         } prm;
 
         /// \copydoc amgcl::relaxation::damped_jacobi::damped_jacobi

--- a/amgcl/relaxation/cusparse_ilu0.hpp
+++ b/amgcl/relaxation/cusparse_ilu0.hpp
@@ -54,6 +54,7 @@ struct ilu0< backend::cuda<real> > {
 
         params() : damping(1) {}
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, damping)
         {
@@ -63,6 +64,7 @@ struct ilu0< backend::cuda<real> > {
         void get(boost::property_tree::ptree &p, const std::string &path) const {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, damping);
         }
+#endif
     } prm;
 
     /// \copydoc amgcl::relaxation::damped_jacobi::damped_jacobi

--- a/amgcl/relaxation/damped_jacobi.hpp
+++ b/amgcl/relaxation/damped_jacobi.hpp
@@ -62,6 +62,7 @@ struct damped_jacobi {
 
         params(scalar_type damping = 0.72) : damping(damping) {}
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, damping)
         {
@@ -71,6 +72,7 @@ struct damped_jacobi {
         void get(boost::property_tree::ptree &p, const std::string &path) const {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, damping);
         }
+#endif
     } prm;
 
     std::shared_ptr<typename Backend::matrix_diagonal> dia;

--- a/amgcl/relaxation/detail/ilu_solve.hpp
+++ b/amgcl/relaxation/detail/ilu_solve.hpp
@@ -59,6 +59,7 @@ class ilu_solve {
 
             params() : iters(2), damping(0.72) {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, iters)
                 , AMGCL_PARAMS_IMPORT_VALUE(p, damping)
@@ -70,6 +71,7 @@ class ilu_solve {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, iters);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, damping);
             }
+#endif
         } prm;
 
     public:
@@ -131,6 +133,7 @@ class ilu_solve< backend::builtin<value_type> > {
 
             params() : serial(num_threads() < 4) {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, serial)
             {
@@ -140,6 +143,7 @@ class ilu_solve< backend::builtin<value_type> > {
             void get(boost::property_tree::ptree &p, const std::string &path) const {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, serial);
             }
+#endif
         } prm;
 
         ilu_solve(

--- a/amgcl/relaxation/gauss_seidel.hpp
+++ b/amgcl/relaxation/gauss_seidel.hpp
@@ -63,6 +63,7 @@ struct gauss_seidel {
 
         params() : serial(false) {}
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, serial)
         {
@@ -72,6 +73,7 @@ struct gauss_seidel {
         void get(boost::property_tree::ptree &p, const std::string &path) const {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, serial);
         }
+#endif
     };
 
     bool is_serial;

--- a/amgcl/relaxation/ilu0.hpp
+++ b/amgcl/relaxation/ilu0.hpp
@@ -67,6 +67,7 @@ struct ilu0 {
 
         params() : damping(1) {}
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, damping)
             , AMGCL_PARAMS_IMPORT_CHILD(p, solve)
@@ -78,6 +79,7 @@ struct ilu0 {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, damping);
             AMGCL_PARAMS_EXPORT_CHILD(p, path, solve);
         }
+#endif
     } prm;
 
     /// \copydoc amgcl::relaxation::damped_jacobi::damped_jacobi

--- a/amgcl/relaxation/iluk.hpp
+++ b/amgcl/relaxation/iluk.hpp
@@ -69,6 +69,7 @@ struct iluk {
 
         params() : k(1), damping(1) {}
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, k)
             , AMGCL_PARAMS_IMPORT_VALUE(p, damping)
@@ -82,6 +83,7 @@ struct iluk {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, damping);
             AMGCL_PARAMS_EXPORT_CHILD(p, path, solve);
         }
+#endif
     } prm;
 
     /// \copydoc amgcl::relaxation::damped_jacobi::damped_jacobi

--- a/amgcl/relaxation/ilut.hpp
+++ b/amgcl/relaxation/ilut.hpp
@@ -79,6 +79,7 @@ struct ilut {
 
         params() : p(2), tau(1e-2f), damping(1) {}
 
+#ifdef BOOST_VERSION
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, p)
             , AMGCL_PARAMS_IMPORT_VALUE(p, tau)
@@ -94,6 +95,7 @@ struct ilut {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, damping);
             AMGCL_PARAMS_EXPORT_CHILD(p, path, solve);
         }
+#endif
     } prm;
 
     /// \copydoc amgcl::relaxation::damped_jacobi::damped_jacobi

--- a/amgcl/solver/bicgstab.hpp
+++ b/amgcl/solver/bicgstab.hpp
@@ -85,6 +85,7 @@ class bicgstab {
                   abstol(std::numeric_limits<scalar_type>::min())
             {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, pside),
                   AMGCL_PARAMS_IMPORT_VALUE(p, maxiter),
@@ -100,6 +101,7 @@ class bicgstab {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, tol);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, abstol);
             }
+#endif
         };
 
         /// Preallocates necessary data structures for the system of size \p n.

--- a/amgcl/solver/bicgstabl.hpp
+++ b/amgcl/solver/bicgstabl.hpp
@@ -131,6 +131,7 @@ class bicgstabl {
             {
             }
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, L),
                   AMGCL_PARAMS_IMPORT_VALUE(p, delta),
@@ -152,6 +153,7 @@ class bicgstabl {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, tol);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, abstol);
             }
+#endif
         };
 
         /// Preallocates necessary data structures for the system of size \p n.

--- a/amgcl/solver/cg.hpp
+++ b/amgcl/solver/cg.hpp
@@ -92,6 +92,7 @@ class cg {
                   abstol(std::numeric_limits<scalar_type>::min())
             {}
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, maxiter),
                   AMGCL_PARAMS_IMPORT_VALUE(p, tol),
@@ -105,6 +106,7 @@ class cg {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, tol);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, abstol);
             }
+#endif
         };
 
         /// Preallocates necessary data structures for the system of size \p n.

--- a/amgcl/solver/fgmres.hpp
+++ b/amgcl/solver/fgmres.hpp
@@ -84,6 +84,7 @@ class fgmres {
                   abstol(std::numeric_limits<scalar_type>::min())
             { }
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, M),
                   AMGCL_PARAMS_IMPORT_VALUE(p, maxiter),
@@ -99,6 +100,7 @@ class fgmres {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, tol);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, abstol);
             }
+#endif
         } prm;
 
         /// Preallocates necessary data structures for the system of size \p n.

--- a/amgcl/solver/gmres.hpp
+++ b/amgcl/solver/gmres.hpp
@@ -90,6 +90,7 @@ class gmres {
                   abstol(std::numeric_limits<scalar_type>::min())
             { }
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, M),
                   AMGCL_PARAMS_IMPORT_VALUE(p, pside),
@@ -107,6 +108,7 @@ class gmres {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, tol);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, abstol);
             }
+#endif
         };
 
         /// Preallocates necessary data structures for the system of size \p n.

--- a/amgcl/solver/idrs.hpp
+++ b/amgcl/solver/idrs.hpp
@@ -124,6 +124,7 @@ class idrs {
                   abstol(std::numeric_limits<scalar_type>::min())
             { }
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, s),
                   AMGCL_PARAMS_IMPORT_VALUE(p, omega),
@@ -145,6 +146,7 @@ class idrs {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, tol);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, abstol);
             }
+#endif
         } prm;
 
         /// Preallocates necessary data structures for the system of size \p n.

--- a/amgcl/solver/lgmres.hpp
+++ b/amgcl/solver/lgmres.hpp
@@ -146,6 +146,7 @@ class lgmres {
                   abstol(std::numeric_limits<scalar_type>::min())
             { }
 
+#ifdef BOOST_VERSION
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, M),
                   AMGCL_PARAMS_IMPORT_VALUE(p, K),
@@ -169,6 +170,7 @@ class lgmres {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, tol);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, abstol);
             }
+#endif
         } prm;
 
         /// Preallocates necessary data structures for the system of size \p n.

--- a/amgcl/util.hpp
+++ b/amgcl/util.hpp
@@ -38,7 +38,10 @@ THE SOFTWARE.
 #include <complex>
 #include <limits>
 #include <stdexcept>
-#include <boost/property_tree/ptree.hpp>
+
+#ifdef BOOST_VERSION
+#  include <boost/property_tree/ptree.hpp>
+#endif
 
 /* Performance measurement macros
  *
@@ -84,6 +87,8 @@ void precondition(const Condition &condition, const Message &message) {
 #  pragma warning(pop)
 #endif
 }
+
+#ifdef BOOST_VERSION
 
 #define AMGCL_PARAMS_IMPORT_VALUE(p, name)                                     \
     name( p.get(#name, params().name) )
@@ -155,6 +160,33 @@ inline void put(boost::property_tree::ptree &p, const std::string &param) {
         throw std::invalid_argument("param in amgcl::put() should have \"key=value\" format!");
     p.put(param.substr(0, eq_pos), param.substr(eq_pos + 1));
 }
+
+#endif
+
+namespace detail {
+
+#ifdef BOOST_VERSION
+inline const boost::property_tree::ptree& empty_ptree() {
+    static const boost::property_tree::ptree p;
+    return p;
+}
+#endif
+
+struct empty_params {
+    empty_params() {}
+
+#ifdef BOOST_VERSION
+    empty_params(const boost::property_tree::ptree &p) {
+        for(const auto &v : p) {
+            AMGCL_PARAM_UNKNOWN(v.first);
+        }
+    }
+    void get(boost::property_tree::ptree&, const std::string&) const {}
+#endif
+};
+
+} // namespace detail
+
 
 // N-dimensional dense matrix
 template <class T, int N>
@@ -259,22 +291,8 @@ class circular_buffer {
         std::vector<T> buf;
 };
 
+
 namespace detail {
-
-inline const boost::property_tree::ptree& empty_ptree() {
-    static const boost::property_tree::ptree p;
-    return p;
-}
-
-struct empty_params {
-    empty_params() {}
-    empty_params(const boost::property_tree::ptree &p) {
-        for(const auto &v : p) {
-            AMGCL_PARAM_UNKNOWN(v.first);
-        }
-    }
-    void get(boost::property_tree::ptree&, const std::string&) const {}
-};
 
 template <class T>
 T eps(size_t n) {

--- a/amgcl/util.hpp
+++ b/amgcl/util.hpp
@@ -38,6 +38,7 @@ THE SOFTWARE.
 #include <complex>
 #include <limits>
 #include <stdexcept>
+#include <cstddef>
 
 #ifdef BOOST_VERSION
 #  include <boost/property_tree/ptree.hpp>


### PR DESCRIPTION
(or boost is otherwise available)