### PR TITLE
cpr and cpr_drs: Introduce member function for updating s_precond

### DIFF
--- a/amgcl/preconditioner/cpr.hpp
+++ b/amgcl/preconditioner/cpr.hpp
@@ -129,6 +129,14 @@ class cpr {
             return S->system_matrix();
         }
 
+        template <class Matrix>
+        void update_sprecond(
+                const Matrix &K,
+                const backend_params bprm = backend_params())
+        {
+            S = std::make_shared<SPrecond>(K, prm.sprecond, bprm);
+        }
+
     private:
         size_t n, np;
 

--- a/amgcl/preconditioner/cpr_drs.hpp
+++ b/amgcl/preconditioner/cpr_drs.hpp
@@ -156,6 +156,14 @@ class cpr_drs {
             return S->system_matrix();
         }
 
+        template <class Matrix>
+        void update_sprecond(
+                const Matrix &K,
+                const backend_params bprm = backend_params())
+        {
+            S = std::make_shared<SPrecond>(K, prm.sprecond, bprm);
+        }
+
     private:
         size_t n, np;
 


### PR DESCRIPTION
Updates to both CPR solvers to support separate updating of the top-level matrix and the corresponding preconditioner `s_precond` as suggested in https://github.com/ddemidov/amgcl/issues/115