### PR TITLE
CPR: implement partial_update and remove update_sprecond

### DIFF
--- a/amgcl/preconditioner/cpr.hpp
+++ b/amgcl/preconditioner/cpr.hpp
@@ -150,14 +150,6 @@ class cpr {
         }
 
         template <class Matrix>
-        void update_sprecond(
-                const Matrix &K,
-                const backend_params &bprm = backend_params())
-        {
-            S = std::make_shared<SPrecond>(K, prm.sprecond, bprm);
-        }
-
-        template <class Matrix>
         void partial_update(
                 const Matrix &K,
                 bool update_transfer_ops = true,

--- a/amgcl/preconditioner/cpr.hpp
+++ b/amgcl/preconditioner/cpr.hpp
@@ -421,6 +421,8 @@ class cpr {
                                     v(k[i].col() % B, i) = k[i].value();
 
                             invert(v.data(), &fpp->val[ik]);
+                            // Diagonal block complete
+                            break;
                         } else {
                             // This is off-diagonal block.
                             // Just skip it.

--- a/amgcl/preconditioner/cpr.hpp
+++ b/amgcl/preconditioner/cpr.hpp
@@ -156,12 +156,13 @@ class cpr {
                 const backend_params &bprm = backend_params()
               )
         {
+            auto K_ptr = std::make_shared<build_matrix>(K);
             // Update global preconditioner
-            S = std::make_shared<SPrecond>(K, prm.sprecond, bprm);
+            S = std::make_shared<SPrecond>(K_ptr, prm.sprecond, bprm);
             if(update_transfer_ops){
               // Update transfer operator Fpp
               update_transfer(
-                  std::make_shared<build_matrix>(K),
+                  K_ptr,
                   bprm,
                   std::integral_constant<bool, math::static_rows<value_type>::value == 1>()
                 );

--- a/amgcl/preconditioner/cpr_drs.hpp
+++ b/amgcl/preconditioner/cpr_drs.hpp
@@ -186,12 +186,13 @@ class cpr_drs {
                 const backend_params &bprm = backend_params()
               )
         {
+            auto K_ptr = std::make_shared<build_matrix>(K);
             // Update global preconditioner
-            S = std::make_shared<SPrecond>(K, prm.sprecond, bprm);
+            S = std::make_shared<SPrecond>(K_ptr, prm.sprecond, bprm);
             if(update_transfer_ops){
               // Update transfer operator Fpp
               update_transfer(
-                  std::make_shared<build_matrix>(K),
+                  K_ptr,
                   bprm,
                   std::integral_constant<bool, math::static_rows<value_type>::value == 1>()
                 );

--- a/amgcl/preconditioner/cpr_drs.hpp
+++ b/amgcl/preconditioner/cpr_drs.hpp
@@ -175,14 +175,6 @@ class cpr_drs {
             return S->system_matrix();
         }
 
-        template <class Matrix>
-        void update_sprecond(
-                const Matrix &K,
-                const backend_params &bprm = backend_params())
-        {
-            S = std::make_shared<SPrecond>(K, prm.sprecond, bprm);
-        }
-
         /* Perform a partial update of the CPR preconditioner. This function
          * leaves the AMG hierarchy intact, but updates the global preconditioner
          * SPrecond and optionally also the transfer operator Fpp.


### PR DESCRIPTION
This is a follow-up to pull request #117. Here, we replace the `update_sprecond` member function to a more general `partial_update` which updates `SPrecond` and can optionally also update `Fpp` (transfer matrix to obtain pressure right-hand-side).

A few questions/observations:
1) There is a fair bit of duplication between `update_sprecond` and `init` now, especially for `cpr_drs`. I considered factoring out the `Fpp` logic, but that would an additional pass through the matrix in the `init` stage and expose the intermediate `fpp` representation. I'm not sure if it is worth it, since most users will probably use cpr directly.
2) I put the functions in the order `init (scalar), partial_update (scalar), init (block), partial_update (block)`. I can switch it around if preferred.
3) I put the backend parameters as a third input to `partial_update`. I think this matches the convention elsewhere in the library.