### PR TITLE
Fix Fortran issues in Windows

### DIFF
--- a/delphi/amgcl.pas
+++ b/delphi/amgcl.pas
@@ -113,21 +113,21 @@ Type
 Var
     hlib: Integer;
 
-    amgcl_params_create: function: Pointer; stdcall;
+    amgcl_params_create: function: Pointer; cdecl;
 
     amgcl_params_seti: procedure(
         p:     Pointer;
         name:  PChar;
         value: Integer
-        ); stdcall;
+        ); cdecl;
 
     amgcl_params_setf: procedure(
         p:     Pointer;
         name:  PChar;
         value: Single
-        ); stdcall;
+        ); cdecl;
 
-    amgcl_params_destroy: procedure(p: Pointer); stdcall;
+    amgcl_params_destroy: procedure(p: Pointer); cdecl;
 
     amgcl_solver_create: function(
         coarsening:  TCoarsening;
@@ -138,13 +138,13 @@ Var
         ptr:         PInteger;
         col:         PInteger;
         val:         PDouble
-        ): Pointer; stdcall;
+        ): Pointer; cdecl;
 
     amgcl_solver_solve: function(
         h:   Pointer;
         rhs: PDouble;
         x:   PDouble
-        ): TConvInfo; stdcall;
+        ): TConvInfo; cdecl;
 
     amgcl_solver_solve_mtx: procedure(
         h:     Pointer;
@@ -153,9 +153,9 @@ Var
         A_val: PDouble;
         rhs:   PDouble;
         x:     PDouble
-        ); stdcall;
+        ); cdecl;
 
-    amgcl_solver_destroy: procedure(h: Pointer); stdcall;
+    amgcl_solver_destroy: procedure(h: Pointer); cdecl;
 
 constructor TParams.Create;
 begin

--- a/fortran/amgcl.f90
+++ b/fortran/amgcl.f90
@@ -53,8 +53,7 @@ module amgcl
             integer (c_size_t), intent(in), value :: prm
         end function
 
-        type(conv_info) &
-        function amgcl_solver_solve(solver, rhs, x) bind (C, name="amgcl_solver_solve")
+        subroutine amgcl_solver_solve_c(solver, rhs, x, cnv) bind (C, name="amgcl_solver_solve_f")
             use iso_c_binding
             integer (c_size_t), intent(in), value :: solver
             real    (c_double), intent(in)        :: rhs(*)
@@ -64,7 +63,9 @@ module amgcl
                 integer (c_int)    :: iterations;
                 real    (c_double) :: residual
             end type
-        end function
+
+            type(conv_info), intent(out) :: cnv
+        end subroutine
 
         subroutine amgcl_solver_report(solver) bind(C, name="amgcl_solver_report")
             use iso_c_binding
@@ -105,5 +106,23 @@ module amgcl
 
         call amgcl_params_sets_c(prm, name // c_null_char, val // c_null_char)
     end subroutine
+
+    type(conv_info) &
+    function amgcl_solver_solve(solver, rhs, x)
+        use iso_c_binding
+        integer (c_size_t), intent(in), value :: solver
+        real    (c_double), intent(in)        :: rhs(*)
+        real    (c_double), intent(inout)     :: x(*)
+
+        type, bind(C) :: conv_info
+            integer (c_int)    :: iterations;
+            real    (c_double) :: residual
+        end type
+
+        type(conv_info) :: cnv;
+
+        call amgcl_solver_solve_c(solver, rhs, x, cnv);
+        amgcl_solver_solve = cnv;
+    end function
 
 end module

--- a/lib/amgcl.cpp
+++ b/lib/amgcl.cpp
@@ -206,6 +206,17 @@ conv_info STDCALL amgcl_solver_solve(
 }
 
 //---------------------------------------------------------------------------
+void STDCALL amgcl_solver_solve_f(
+        amgclHandle handle,
+        const double *rhs,
+        double *x,
+        conv_info *cnv
+        )
+{
+    *cnv = amgcl_solver_solve(handle, rhs, x);
+}
+
+//---------------------------------------------------------------------------
 conv_info STDCALL amgcl_solver_solve_mtx(
         amgclHandle handle,
         int    const * A_ptr,

--- a/lib/amgcl.h
+++ b/lib/amgcl.h
@@ -32,7 +32,7 @@ THE SOFTWARE.
  */
 
 #ifdef WIN32
-#  define STDCALL __stdcall
+#  define STDCALL __cdecl
 #else
 #  define STDCALL
 #endif
@@ -119,6 +119,14 @@ conv_info STDCALL amgcl_solver_solve(
         amgclHandle    solver,
         double const * rhs,
         double       * x
+        );
+
+// Solve the problem for the given right-hand side.
+void STDCALL amgcl_solver_solve_f(
+        amgclHandle    solver,
+        double const * rhs,
+        double       * x,
+        conv_info    * cnv
         );
 
 // Solve the problem for the given matrix and the right-hand side.

--- a/lib/dll.def
+++ b/lib/dll.def
@@ -14,6 +14,7 @@ EXPORTS
     amgcl_solver_create
     amgcl_solver_create_f
     amgcl_solver_solve
+    amgcl_solver_solve_f
     amgcl_solver_solve_mtx
     amgcl_solver_destroy
     amgcl_solver_report


### PR DESCRIPTION
Fixes #153

* Replaces `__stdcall` with `__cdecl` in [lib/amgcl.h](https://github.com/ddemidov/amgcl/blob/master/lib/amgcl.h)
* Introduces helper function `amgcl_solver_solve_f` that takes the output struct by pointer.

@xiangyue1993, would this work for you?