### PR TITLE
Add empty statements for OpenMP barriers (MSVC compile fix)

### DIFF
--- a/amgcl/relaxation/detail/ilu_solve.hpp
+++ b/amgcl/relaxation/detail/ilu_solve.hpp
@@ -408,6 +408,7 @@ class ilu_solve< backend::builtin<value_type> > {
                         // each task corresponds to a level, so we need
                         // to synchronize across threads at this point:
 #pragma omp barrier
+                        ;
                     }
                 }
             }

--- a/amgcl/relaxation/gauss_seidel.hpp
+++ b/amgcl/relaxation/gauss_seidel.hpp
@@ -350,6 +350,7 @@ struct gauss_seidel {
                         // each task corresponds to a level, so we need
                         // to synchronize across threads at this point:
 #pragma omp barrier
+                        ;
                     }
                 }
             }


### PR DESCRIPTION
With the latest Visual Studio 2019 and compiling with C++17 as the standard, compile errors are generated from these two statements complaining that the omp barriers need an actual statement to make as the barrier (not just }).
```
Severity	Code	Description	Project	File	Line	Suppression State
Error	C2760	syntax error: unexpected token '}', expected 'statement' (compiling source file blah.cpp)	MyProject	C:\amgcl\amgcl\relaxation\detail\ilu_solve.hpp	412	
```
This PR solves this issue in the simplest way I could think of.