### PR TITLE
Add missing including of cassert

### DIFF
--- a/amgcl/backend/vexcl_static_matrix.hpp
+++ b/amgcl/backend/vexcl_static_matrix.hpp
@@ -31,6 +31,7 @@ THE SOFTWARE.
  * \brief  Static matrix support for the VexCL backend.
  */
 
+#include <cassert>
 #include <amgcl/backend/detail/mixing.hpp>
 #include <amgcl/backend/vexcl.hpp>
 #include <amgcl/value_type/static_matrix.hpp>

--- a/amgcl/detail/inverse.hpp
+++ b/amgcl/detail/inverse.hpp
@@ -33,6 +33,7 @@ THE SOFTWARE.
 
 #include <vector>
 #include <algorithm>
+#include <cassert>
 #include <amgcl/util.hpp>
 #include <amgcl/value_type/interface.hpp>
 

--- a/amgcl/mpi/coarsening/pmis.hpp
+++ b/amgcl/mpi/coarsening/pmis.hpp
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include <tuple>
 #include <memory>
 #include <numeric>
+#include <cassert>
 
 #include <amgcl/backend/builtin.hpp>
 #include <amgcl/util.hpp>

--- a/amgcl/mpi/cpr.hpp
+++ b/amgcl/mpi/cpr.hpp
@@ -31,6 +31,7 @@ THE SOFTWARE.
  * \brief  Distributed CPR preconditioner.
  */
 
+#include <cassert>
 #include <amgcl/backend/builtin.hpp>
 #include <amgcl/util.hpp>
 #include <amgcl/mpi/inner_product.hpp>

--- a/amgcl/preconditioner/cpr.hpp
+++ b/amgcl/preconditioner/cpr.hpp
@@ -33,6 +33,7 @@ THE SOFTWARE.
 
 #include <vector>
 #include <memory>
+#include <cassert>
 
 #include <amgcl/backend/builtin.hpp>
 #include <amgcl/util.hpp>

--- a/examples/mpi/mba.hpp
+++ b/examples/mpi/mba.hpp
@@ -40,6 +40,7 @@ THE SOFTWARE.
 #include <array>
 #include <memory>
 #include <functional>
+#include <cassert>
 
 #include <boost/container/flat_map.hpp>
 #include <boost/multi_array.hpp>

--- a/examples/mpi/solve_mm_mpi.cpp
+++ b/examples/mpi/solve_mm_mpi.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <numeric>
 #include <cmath>
+#include <cassert>
 #ifdef _OPENMP
 #include <omp.h>
 #endif


### PR DESCRIPTION
Add missing `#include <cassert>` directives to the files where assert macro is used. This adds the include to the end of system includes, without any reordering (there does not seem to be any include ordering policy except system includes first).

Closes #185