### PR TITLE
Initializing thread-local variables to zero

### DIFF
--- a/amgcl/backend/builtin.hpp
+++ b/amgcl/backend/builtin.hpp
@@ -1147,8 +1147,11 @@ struct inner_product_impl<
 
         if (nt < 64) {
             sum = _sum_stat;
+            for(int i = 0; i < nt; ++i) {
+                sum[i] = math::zero<return_type>();
+            }
         } else {
-            _sum_dyna.resize(nt);
+            _sum_dyna.resize(nt, math::zero<return_type>());
             sum = _sum_dyna.data();
         }
 


### PR DESCRIPTION
If compiled with `_OPENMP`, `math::inner_product` uses thread-local sums which are not initialized.
This can lead to uninitialized variables being accumulated, thus causing undefined behavior.

The PR explicitly initializes all thread-local sums to zero. This fixed the issue for me.