### PR TITLE
Deprecation of Eigen::MappedSparseMatrix 

### DIFF
--- a/amgcl/adapter/eigen.hpp
+++ b/amgcl/adapter/eigen.hpp
@@ -51,7 +51,7 @@ struct is_eigen_type : std::false_type {};
 
 template <typename Scalar, int Flags, typename Storage>
 struct is_eigen_sparse_matrix<
-    Eigen::MappedSparseMatrix<Scalar, Flags, Storage>
+    Eigen::Map<Eigen::SparseMatrix<Scalar, Flags, Storage>>
     > : std::true_type
 {};
 

--- a/amgcl/backend/eigen.hpp
+++ b/amgcl/backend/eigen.hpp
@@ -54,7 +54,7 @@ struct eigen {
     typedef ptrdiff_t ptr_type;
 
     typedef
-        Eigen::MappedSparseMatrix<value_type, Eigen::RowMajor, index_type>
+        Eigen::Map<Eigen::SparseMatrix<value_type, Eigen::RowMajor, index_type>>
         matrix;
 
     typedef Eigen::Matrix<value_type, Eigen::Dynamic, 1> vector;

--- a/amgcl/solver/eigen.hpp
+++ b/amgcl/solver/eigen.hpp
@@ -76,7 +76,7 @@ class EigenSolver {
 
             S.compute(
                     MatrixType(
-                        Eigen::MappedSparseMatrix<value_type, Eigen::RowMajor, ptrdiff_t>(
+                        Eigen::Map<Eigen::SparseMatrix<value_type, Eigen::RowMajor, ptrdiff_t>>(
                             backend::rows(A), backend::cols(A), backend::nonzeros(A),
                             const_cast<ptr_type*>(backend::ptr_data(A)),
                             const_cast<col_type*>(backend::col_data(A)),


### PR DESCRIPTION
Eigen::MappedSparseMatrix is deprecated and already removed in the latest gitlab version of Eigen, but not yet in the official release 3.4.0. 

Updating Eigen::MappedSparseMatrix to Eigen::Map<Eigen::SparseMatrix<>> prevents compilation issues with upcoming releases of Eigen.