### PR TITLE
Request minimum 3.0 MPI version for MPI_CXX_* constants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ endif()
 #----------------------------------------------------------------------------
 # Find MPI
 #----------------------------------------------------------------------------
-find_package(MPI)
+find_package(MPI 3.0)
 if (MPI_CXX_FOUND)
     # Need this to comply with CMP004 policy:
     string(STRIP "${MPI_CXX_LINK_FLAGS}" MPI_CXX_LINK_FLAGS)


### PR DESCRIPTION
Otherwise, cmake might still use a pre-3.0 MPI implementation (for example MS-MPI), that could compile on c++, but will not support MPI_CXX_* constants that amgcl uses.

You could still want to support pre-3.0 MPI implementations, but then you would need to prevent the use of `std::complex` and replace it with something more C like.