### PR TITLE
add initialization in block_matrix to fix GCC 12 warning

### DIFF
--- a/amgcl/adapter/block_matrix.hpp
+++ b/amgcl/adapter/block_matrix.hpp
@@ -73,7 +73,7 @@ struct block_matrix_adapter {
         typedef ptrdiff_t col_type;
         typedef BlockType val_type;
 
-        std::array<char, sizeof(Base) * BlockSize> buf;
+        std::array<char, sizeof(Base) * BlockSize> buf {};
         Base * base;
 
         bool done;


### PR DESCRIPTION
Without this, GCC 12 issues the following warning:
~~~
/__w/Kratos/Kratos/external_libraries/amgcl/adapter/block_matrix.hpp:84:44: error: member 'amgcl::adapter::block_matrix_adapter<amgcl::backend::crs<float, long int, long int>, amgcl::static_matrix<float, 3, 3> >::row_iterator::buf' is used uninitialized [-Werror=uninitialized]
~~~