### PR TITLE
Udpdate condition for setting CMake's Boost policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 project(AMGCL)
 
-if (NOT (CMAKE_VERSION LESS 3.3))
+if (CMAKE_VERSION LESS 3.3)
     cmake_policy(SET CMP0058 OLD)
 endif()
 


### PR DESCRIPTION
[Line 9](https://github.com/ddemidov/amgcl/blob/master/CMakeLists.txt#L9) of `CMakeLists.txt` sets CMake's Boost policy to `OLD` if CMake is older than version 3.3, though I think this if-condition should be negated according to the CMake Error on policy CMP0058 that occurs if I try to use a newer version:

```
The policy was introduced in CMake version 3.3.0, and use of NEW behavior is now required.
```

Simply removing `NOT` in the if-condition leads to successful builds on MacOS using both CMake 3.3.0 and CMake 4.0.2.