### PR TITLE
Allow to modify the iterative solver after construction

### DIFF
--- a/amgcl/make_solver.hpp
+++ b/amgcl/make_solver.hpp
@@ -189,6 +189,11 @@ class make_solver : public amgcl::detail::non_copyable {
             return S;
         }
 
+        /// Returns reference to the constructed iterative solver.
+        IterativeSolver& solver() {
+            return S;
+        }
+
         /// Returns the system matrix in the backend format.
         std::shared_ptr<typename Precond::matrix> system_matrix_ptr() const {
             return P.system_matrix_ptr();


### PR DESCRIPTION
Currently, there is no way to modify the iterative solver after construction, for example to change the number of iterations requested for the iterative solver. This small PR just add the possibility to obtain a reference to the solver to do such modifications, like for the preconditioner.