### PR TITLE
fix(#297) allow rebuild from other backend

### DIFF
--- a/amgcl/mpi/amg.hpp
+++ b/amgcl/mpi/amg.hpp
@@ -196,6 +196,16 @@ class amg {
             rebuild(std::make_shared<matrix>(comm, M, backend::rows(M)), bprm);
         }
 
+        template <class OtherBackend>
+        typename std::enable_if<!std::is_same<Backend, OtherBackend>::value, void>::type
+        rebuild(
+                std::shared_ptr<distributed_matrix<OtherBackend>> A,
+                const backend_params &bprm = backend_params()
+        )
+        {
+            return rebuild(std::make_shared<matrix>(*A), bprm);
+        }
+
         void rebuild(
                 std::shared_ptr<matrix> A,
                 const backend_params &bprm = backend_params()


### PR DESCRIPTION
Accept matrices from other backend for amgcl::mpi::amg::rebuild