### PR TITLE
[Relaxation] Enhance ILU(0) Chow-Patel: underrelaxation, symmetric scaling, and robustness

### DIFF
--- a/amgcl/mpi/relaxation/ilu0_chow_patel.hpp
+++ b/amgcl/mpi/relaxation/ilu0_chow_patel.hpp
@@ -27,7 +27,7 @@ THE SOFTWARE.
 
 /**
  * \file   amgcl/mpi/relaxation/ilu0_chow_patel.hpp
- * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \author Vicente Mataix Ferrandiz <vicente.mataix-ferrandiz@siemens.com>
  * \brief  Distributed memory fine-grained parallel ILU(0) (Chow-Patel).
  */
 

--- a/amgcl/relaxation/ilu0_chow_patel.hpp
+++ b/amgcl/relaxation/ilu0_chow_patel.hpp
@@ -42,9 +42,20 @@ THE SOFTWARE.
  * nonzero of L and U can be updated independently, giving fine-grained
  * parallelism that scales well regardless of matrix ordering.
  *
- * The matrix is row-scaled to have a unit diagonal before factorization,
- * as recommended by the paper for convergence.  The scaling is undone
- * when constructing the final factors for the preconditioner.
+ * The matrix is scaled to have a unit diagonal before factorization,
+ * as recommended by the paper for convergence.  Two scaling strategies
+ * are available:
+ *   - Row scaling:       A' = diag(1/a_ii) * A             (default)
+ *   - Symmetric scaling: A' = diag(1/sqrt|a_ii|)*A*diag(1/sqrt|a_ii|)
+ *
+ * Symmetric scaling (DAD) is recommended by the paper (Section 2.3) and
+ * generally gives better convergence because it balances both rows and
+ * columns.  Row scaling is kept as the default for backward compatibility
+ * and because it can be more robust when the diagonal entries have very
+ * large magnitude variation.
+ *
+ * An underrelaxation factor omega can be used to stabilize the
+ * fixed-point iteration for non-diagonally-dominant matrices.
  */
 
 #include <vector>
@@ -92,23 +103,38 @@ struct ilu0_chow_patel {
         /// Number of fixed-point iteration sweeps for computing L and U.
         int sweeps;
 
+        /// Underrelaxation factor for the fixed-point sweeps (0 < omega <= 1).
+        /// Values less than 1 dampen the update and can stabilize convergence
+        /// for non-diagonally-dominant matrices at the cost of slower
+        /// convergence for well-conditioned ones.
+        scalar_type omega;
+
+        /// Use symmetric diagonal scaling (DAD) instead of row scaling (DA).
+        /// Symmetric scaling often improves convergence of the iterative
+        /// factorization (see Section 2.3 of Chow & Patel 2015).
+        bool symmetric_scaling;
+
         /// Parameters for sparse triangular system solver.
         typename ilu_solve::params solve;
 
-        params() : damping(1), sweeps(2) {}
+        params() : damping(1), sweeps(5), omega(0.8), symmetric_scaling(false) {}
 
 #ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, damping)
             , AMGCL_PARAMS_IMPORT_VALUE(p, sweeps)
+            , AMGCL_PARAMS_IMPORT_VALUE(p, omega)
+            , AMGCL_PARAMS_IMPORT_VALUE(p, symmetric_scaling)
             , AMGCL_PARAMS_IMPORT_CHILD(p, solve)
         {
-            check_params(p, {"damping", "sweeps", "solve"});
+            check_params(p, {"damping", "sweeps", "omega", "symmetric_scaling", "solve"});
         }
 
         void get(boost::property_tree::ptree &p, const std::string &path) const {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, damping);
             AMGCL_PARAMS_EXPORT_VALUE(p, path, sweeps);
+            AMGCL_PARAMS_EXPORT_VALUE(p, path, omega);
+            AMGCL_PARAMS_EXPORT_VALUE(p, path, symmetric_scaling);
             AMGCL_PARAMS_EXPORT_CHILD(p, path, solve);
         }
 #endif
@@ -126,13 +152,42 @@ struct ilu0_chow_patel {
 
         // -----------------------------------------------------------------
         // 1. Diagonal scaling.
-        //    Row-scale A so that the diagonal is the identity:
-        //      A' = diag(1/a_ii) * A.
-        //    backend::diagonal(A, true) returns a numa_vector of 1/a_ii
-        //    computed in a parallel loop with correct NUMA first-touch.
+        //    Compute per-row scale factors so the scaled matrix has unit
+        //    diagonal.  Two strategies are supported:
+        //
+        //    Row scaling (default):
+        //      A' = diag(d_i) * A,  where d_i = 1/a_ii.
+        //
+        //    Symmetric scaling (Section 2.3 of the paper):
+        //      A' = diag(d_i) * A * diag(d_i),  where d_i = 1/sqrt(|a_ii|).
+        //      This balances both rows and columns and generally gives
+        //      better convergence when the matrix is far from diagonally
+        //      dominant.
+        //
+        //    In both cases, scale[i] stores the left (row) scale factor.
+        //    For symmetric scaling col_scale[j] stores the column factor
+        //    (same array – it equals scale[j]).
         // -----------------------------------------------------------------
         auto inv_diag_ptr = backend::diagonal(A, /*invert=*/true);
-        auto &inv_diag = *inv_diag_ptr;
+        auto &inv_diag = *inv_diag_ptr;  // inv_diag[i] = 1/a_ii
+
+        // scale[i] is the left scale factor d_i for row i.
+        backend::numa_vector<value_type> scale(n, false);
+#ifdef _OPENMP
+#  pragma omp parallel for schedule(guided, 64)
+#endif
+        for (ptrdiff_t i = 0; i < n; ++i) {
+            if (prm.symmetric_scaling) {
+                // d_i = 1 / sqrt(|a_ii|)
+                scalar_type abs_aii = math::norm(math::inverse(inv_diag[i]));
+                scale[i] = (abs_aii > std::numeric_limits<scalar_type>::min())
+                    ? static_cast<scalar_type>(1.0 / std::sqrt(abs_aii)) * math::identity<value_type>()
+                    : inv_diag[i];
+            } else {
+                // d_i = 1 / a_ii  (row scaling)
+                scale[i] = inv_diag[i];
+            }
+        }
 
         // -----------------------------------------------------------------
         // 2. Count nonzeros per row and build prefix-sum Lptr / Uptr.
@@ -175,7 +230,9 @@ struct ilu0_chow_patel {
         //      L^(0)_{ij} = a'_{ij}      (i > j)
         //      U^(0)_{ij} = a'_{ij}      (i < j)
         //      U^(0)_{ii} = 1            (unit diagonal after scaling)
-        //    where a'_{ij} = a_{ij} / a_{ii}.
+        //
+        //    Row scaling:       a'_{ij} = a_{ij} * scale[i]
+        //    Symmetric scaling: a'_{ij} = a_{ij} * scale[i] * scale[j]
         //
         //    The loop is parallel so that each thread first-touches its own
         //    slice of Lcol/Lval, Ucol/Uval, and Udiag – matching the access
@@ -188,7 +245,10 @@ struct ilu0_chow_patel {
             ptr_type lh = Lptr[i], uh = Uptr[i];
             for (ptr_type j = A.ptr[i]; j < A.ptr[i + 1]; ++j) {
                 ptrdiff_t c = A.col[j];
-                value_type v = A.val[j] * inv_diag[i]; // row-scaling
+                // Scale: row scaling  a'_ij = a_ij * scale[i]
+                //        sym scaling  a'_ij = a_ij * scale[i] * scale[c]
+                value_type v = A.val[j] * scale[i];
+                if (prm.symmetric_scaling) v = v * scale[c];
                 if (c < i) {
                     Lcol[lh] = static_cast<col_type>(c);
                     Lval[lh] = v;
@@ -284,8 +344,6 @@ struct ilu0_chow_patel {
             }
         };
 
-        build_ucsc();
-
         // -----------------------------------------------------------------
         // 5. Fixed-point iteration sweeps (Algorithm 2 from the paper).
         //
@@ -296,11 +354,26 @@ struct ilu0_chow_patel {
         //
         //    The inner products are sparse-sparse dot products between
         //    row i of L (CSR) and column j of U (CSC).
+        //
+        //    When omega < 1, each update is under-relaxed:
+        //      x_new = omega * G(x) + (1 - omega) * x_old
+        //    This can stabilize convergence for non-diagonally-dominant
+        //    matrices at the cost of slower convergence.
         // -----------------------------------------------------------------
+        const scalar_type omega   = prm.omega;
+        const scalar_type one_m_w = static_cast<scalar_type>(1) - omega;
+
+        // Minimum acceptable pivot norm (relative to identity).
+        // Using sqrt(eps) instead of eps gives much more robust behavior
+        // for ill-conditioned matrices.
+        const scalar_type pivot_tol =
+            std::sqrt(std::numeric_limits<scalar_type>::epsilon())
+            * math::norm(math::identity<value_type>());
+
         for (int sweep = 0; sweep < prm.sweeps; ++sweep) {
             // Synchronize CSC copy of U with (possibly updated) CSR values.
-            // First sweep builds full CSC structure; subsequent sweeps only
-            // update the values (structure is invariant).
+            // First sweep builds the full CSC structure + values; subsequent
+            // sweeps only update the values (structure is invariant).
             if (sweep == 0)
                 build_ucsc();
             else
@@ -328,11 +401,18 @@ struct ilu0_chow_patel {
                         else { s += Lval[lp] * Ucval[up]; ++lp; ++up; }
                     }
 
-                    // Guard against zero pivot (broken factorization).
+                    // Guard against zero pivot.
                     value_type pivot = Udiag[j];
-                    if (math::norm(pivot) < std::numeric_limits<scalar_type>::epsilon() * math::norm(math::identity<value_type>()))
-                        pivot = std::numeric_limits<scalar_type>::epsilon() * math::identity<value_type>();
-                    Lval[jj] = (a_L[jj] - s) * math::inverse(pivot);
+                    if (math::norm(pivot) < pivot_tol)
+                        pivot = pivot_tol * math::identity<value_type>();
+
+                    value_type l_new = (a_L[jj] - s) * math::inverse(pivot);
+
+                    // Protect against NaN/Inf from numerical blow-up.
+                    if (!std::isfinite(math::norm(l_new))) l_new = a_L[jj];
+
+                    // Under-relaxation.
+                    Lval[jj] = omega * l_new + one_m_w * Lval[jj];
                 }
             }
 
@@ -355,7 +435,10 @@ struct ilu0_chow_patel {
                         else if (lc > uc) { ++up; }
                         else { s += Lval[lp] * Ucval[up]; ++lp; ++up; }
                     }
-                    Udiag[i] = math::identity<value_type>() - s;
+                    value_type u_diag_new = math::identity<value_type>() - s;
+                    if (!std::isfinite(math::norm(u_diag_new)))
+                        u_diag_new = math::identity<value_type>();
+                    Udiag[i] = omega * u_diag_new + one_m_w * Udiag[i];
                 }
 
                 // u_ij for j > i
@@ -375,7 +458,9 @@ struct ilu0_chow_patel {
                         else { s += Lval[lp] * Ucval[up]; ++lp; ++up; }
                     }
 
-                    Uval[jj] = a_U[jj] - s;
+                    value_type u_new = a_U[jj] - s;
+                    if (!std::isfinite(math::norm(u_new))) u_new = a_U[jj];
+                    Uval[jj] = omega * u_new + one_m_w * Uval[jj];
                 }
             }
         }
@@ -383,18 +468,22 @@ struct ilu0_chow_patel {
         // -----------------------------------------------------------------
         // 6. Un-scale and build output factors for ilu_solve.
         //
-        //    We computed L,U for scaled system A' = diag(1/a_ii)*A such that
-        //    L*U ≈ A'.  Therefore  diag(a_ii)*L*U ≈ A.
-        //
         //    ilu_solve expects factors in the form
         //      M = (I + L_s)(diag(pivot) + U_s)
         //    where L_s is strictly lower triangular, U_s is strictly upper
         //    triangular, and it stores D = inv(pivot).
         //
-        //    Decomposing  diag(a_ii)*(I + L_cp)*(diag(Udiag) + U_cp) yields:
-        //      L_s_{ij}  = (a_ii / a_jj) * L_cp_{ij}     (i > j)
-        //      pivot_i   = a_ii * Udiag_i
-        //      U_s_{ij}  = a_ii * U_cp_{ij}               (i < j)
+        //    Row scaling:  A' = diag(1/a_ii)*A,  L'U' ≈ A'.
+        //      (I + L_s)(pivot + U_s) = diag(a_ii)*(I + L')(diag(U'd) + U')
+        //        L_s_{ij}  = (a_ii / a_jj) * L'_{ij}
+        //        pivot_i   = a_ii * U'diag_i
+        //        U_s_{ij}  = a_ii * U'_{ij}
+        //
+        //    Symmetric scaling: A' = D*A*D,  D = diag(1/sqrt|a_ii|).
+        //      (I + L_s)(pivot + U_s) = D^{-1}(I + L')(diag(U'd) + U')D^{-1}
+        //        L_s_{ij}  = sqrt(|a_ii| / |a_jj|) * L'_{ij}
+        //        pivot_i   = |a_ii| * U'diag_i
+        //        U_s_{ij}  = sqrt(|a_ii| * |a_jj|) * U'_{ij}
         // -----------------------------------------------------------------
         auto L_out = std::make_shared<build_matrix>();
         auto U_out = std::make_shared<build_matrix>();
@@ -407,26 +496,54 @@ struct ilu0_chow_patel {
 #  pragma omp parallel for schedule(guided, 64)
 #endif
         for (ptrdiff_t i = 0; i < n; ++i) {
+            // Compute un-scaling factors for row i.
             value_type a_ii = math::inverse(inv_diag[i]);
+            scalar_type abs_aii = math::norm(a_ii);
 
             for (ptr_type jj = Lptr[i]; jj < Lptr[i + 1]; ++jj) {
                 ptrdiff_t j = Lcol[jj];
-                value_type a_jj = math::inverse(inv_diag[j]);
                 L_out->col[jj] = Lcol[jj];
-                L_out->val[jj] = (a_ii * math::inverse(a_jj)) * Lval[jj];
+                if (prm.symmetric_scaling) {
+                    // L_s_{ij} = sqrt(|a_ii| / |a_jj|) * L'_{ij}
+                    scalar_type abs_ajj = math::norm(math::inverse(inv_diag[j]));
+                    scalar_type ratio = (abs_ajj > std::numeric_limits<scalar_type>::min())
+                        ? std::sqrt(abs_aii / abs_ajj)
+                        : static_cast<scalar_type>(1);
+                    L_out->val[jj] = ratio * Lval[jj];
+                } else {
+                    // L_s_{ij} = (a_ii / a_jj) * L'_{ij}
+                    value_type a_jj = math::inverse(inv_diag[j]);
+                    L_out->val[jj] = (a_ii * math::inverse(a_jj)) * Lval[jj];
+                }
             }
             L_out->ptr[i + 1] = Lptr[i + 1];
 
             for (ptr_type jj = Uptr[i]; jj < Uptr[i + 1]; ++jj) {
                 U_out->col[jj] = Ucol[jj];
-                U_out->val[jj] = a_ii * Uval[jj];
+                if (prm.symmetric_scaling) {
+                    // U_s_{ij} = sqrt(|a_ii| * |a_jj|) * U'_{ij}
+                    ptrdiff_t j = Ucol[jj];
+                    scalar_type abs_ajj = math::norm(math::inverse(inv_diag[j]));
+                    scalar_type factor = std::sqrt(abs_aii * abs_ajj);
+                    U_out->val[jj] = factor * Uval[jj];
+                } else {
+                    // U_s_{ij} = a_ii * U'_{ij}
+                    U_out->val[jj] = a_ii * Uval[jj];
+                }
             }
             U_out->ptr[i + 1] = Uptr[i + 1];
 
-            // Guard against zero pivot before storing D = inv(pivot).
-            value_type pivot = a_ii * Udiag[i];
-            if (math::norm(pivot) < std::numeric_limits<scalar_type>::epsilon() * math::norm(math::identity<value_type>()))
-                pivot = std::numeric_limits<scalar_type>::epsilon() * math::identity<value_type>();
+            // Compute pivot and guard against zero.
+            value_type pivot;
+            if (prm.symmetric_scaling) {
+                // pivot_i = |a_ii| * U'diag_i
+                pivot = abs_aii * Udiag[i];
+            } else {
+                // pivot_i = a_ii * U'diag_i
+                pivot = a_ii * Udiag[i];
+            }
+            if (math::norm(pivot) < pivot_tol)
+                pivot = pivot_tol * math::identity<value_type>();
             (*D_out)[i] = math::inverse(pivot);
         }
 

--- a/amgcl/relaxation/ilu0_chow_patel.hpp
+++ b/amgcl/relaxation/ilu0_chow_patel.hpp
@@ -331,7 +331,7 @@ struct ilu0_chow_patel {
                     // Guard against zero pivot (broken factorization).
                     value_type pivot = Udiag[j];
                     if (math::norm(pivot) < std::numeric_limits<scalar_type>::epsilon() * math::norm(math::identity<value_type>()))
-                        pivot = math::identity<value_type>() * std::numeric_limits<scalar_type>::epsilon();
+                        pivot = std::numeric_limits<scalar_type>::epsilon() * math::identity<value_type>();
                     Lval[jj] = (a_L[jj] - s) * math::inverse(pivot);
                 }
             }
@@ -426,7 +426,7 @@ struct ilu0_chow_patel {
             // Guard against zero pivot before storing D = inv(pivot).
             value_type pivot = a_ii * Udiag[i];
             if (math::norm(pivot) < std::numeric_limits<scalar_type>::epsilon() * math::norm(math::identity<value_type>()))
-                pivot = math::identity<value_type>() * std::numeric_limits<scalar_type>::epsilon();
+                pivot = std::numeric_limits<scalar_type>::epsilon() * math::identity<value_type>();
             (*D_out)[i] = math::inverse(pivot);
         }
 

--- a/amgcl/relaxation/ilu0_chow_patel.hpp
+++ b/amgcl/relaxation/ilu0_chow_patel.hpp
@@ -27,7 +27,7 @@ THE SOFTWARE.
 
 /**
  * \file   amgcl/relaxation/ilu0_chow_patel.hpp
- * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \author Vicente Mataix Ferrandiz <vicente.mataix-ferrandiz@siemens.com>
  * \brief  Fine-grained parallel ILU(0) factorization.
  *
  * Parallel ILU(0) factorization based on the iterative algorithm described in:

--- a/amgcl/relaxation/ilu0_chow_patel.hpp
+++ b/amgcl/relaxation/ilu0_chow_patel.hpp
@@ -49,6 +49,7 @@ THE SOFTWARE.
 
 #include <vector>
 #include <cmath>
+#include <limits>
 #include <algorithm>
 
 #ifdef _OPENMP
@@ -327,7 +328,11 @@ struct ilu0_chow_patel {
                         else { s += Lval[lp] * Ucval[up]; ++lp; ++up; }
                     }
 
-                    Lval[jj] = (a_L[jj] - s) * math::inverse(Udiag[j]);
+                    // Guard against zero pivot (broken factorization).
+                    value_type pivot = Udiag[j];
+                    if (math::norm(pivot) < std::numeric_limits<scalar_type>::epsilon() * math::norm(math::identity<value_type>()))
+                        pivot = math::identity<value_type>() * std::numeric_limits<scalar_type>::epsilon();
+                    Lval[jj] = (a_L[jj] - s) * math::inverse(pivot);
                 }
             }
 
@@ -418,7 +423,11 @@ struct ilu0_chow_patel {
             }
             U_out->ptr[i + 1] = Uptr[i + 1];
 
-            (*D_out)[i] = math::inverse(a_ii * Udiag[i]);
+            // Guard against zero pivot before storing D = inv(pivot).
+            value_type pivot = a_ii * Udiag[i];
+            if (math::norm(pivot) < std::numeric_limits<scalar_type>::epsilon() * math::norm(math::identity<value_type>()))
+                pivot = math::identity<value_type>() * std::numeric_limits<scalar_type>::epsilon();
+            (*D_out)[i] = math::inverse(pivot);
         }
 
         ilu = std::make_shared<ilu_solve>(L_out, U_out, D_out, prm.solve, bprm);


### PR DESCRIPTION
---
name: ✨ Enhancement
about: Improve robustness and convergence of the fine-grained parallel ILU(0) Chow-Patel factorization for non-diagonally-dominant matrices.

---

## **📝 Description**

The Chow-Patel fine-grained parallel ILU(0) implementation (`amgcl/relaxation/ilu0_chow_patel.hpp`) uses an iterative fixed-point method to compute the incomplete factorization in parallel (Chow & Patel, SIAM J. Sci. Comput. 37(2), C169–C193, 2015). While this approach is excellent for diagonally dominant matrices, the fixed-point iteration diverges (produces NaN after 1 iteration) on matrices that are far from diagonally dominant — specifically when the Jacobian 1-norm bound:

<img width="223" height="20" alt="image" src="https://github.com/user-attachments/assets/44725836-144c-4f36-91eb-2f4d0893a298" />

This PR introduces three convergence-improving mechanisms that make the preconditioner usable on a significantly broader class of problems, including nonsymmetric systems with off-diagonal elements up to 35× the diagonal (Jacobian norm bound  ≈35).

Continues contributions of https://github.com/ddemidov/amgcl/pull/307

See:

> Edmond Chow and Aftab Patel,
> *"Fine-Grained Parallel Incomplete LU Factorization"*,
> SIAM J. Sci. Comput., 37(2), C169–C193, 2015.
> https://www.doi.org/10.1137/140968896

### **💡 Key changes**

#### 1. Underrelaxation parameter `omega` (default: 0.8)

Added a fixed-point underrelaxation factor that dampens each sweep update:

$$x^{(p+1)} = \omega \cdot G(x^{(p)}) + (1 - \omega) \cdot x^{(p)}$$

Applied uniformly to all L, U off-diagonal, and U diagonal updates. This reduces the effective spectral radius of the iteration operator, stabilizing convergence for non-diagonally-dominant matrices. The parameter is exposed as `precond.omega` and can be tuned per-problem.

**Implementation detail**: The relaxation is applied to each individual entry update within the parallel sweep, preserving the fine-grained parallelism of the original algorithm.

#### 2. Symmetric diagonal scaling option `symmetric_scaling` (default: false)

Added support for symmetric scaling $A' = D A D$ where $D = \text{diag}(1/\sqrt{|a_{ii}|})$, in addition to the existing row scaling $A' = \text{diag}(1/a_{ii}) \cdot A$.

Symmetric scaling balances both rows and columns of the matrix, generally producing smaller off-diagonal entries in the scaled system and improving convergence of the fixed-point iteration (Section 2.3 of the paper). The un-scaling in step 6 is derived as:

- **Row scaling**:  

<img width="175" height="89" alt="image" src="https://github.com/user-attachments/assets/6da2aac4-1f8c-46b7-aaff-734c4e999739" />

- **Symmetric scaling**: 

<img width="206" height="115" alt="image" src="https://github.com/user-attachments/assets/38fcc5b5-de35-4ead-bfc7-2df0eee6f058" />

The derivation follows from $A \approx D^{-1}(I+L')(U'_d + U')D^{-1}$ and matching the `ilu_solve` interface $(I + L_s)(\text{diag}(\text{pivot}) + U_s)$.

#### 3. Robustness improvements

- **Pivot threshold raised from `epsilon` to `sqrt(epsilon)`**: The zero-pivot guard in both the sweep loop and the final un-scaling now uses $\sqrt{\varepsilon} \approx 1.49 \times 10^{-8}$ (double) instead of $\varepsilon \approx 2.2 \times 10^{-16}$, preventing catastrophic amplification from near-singular pivots.

- **NaN/Inf protection**: Each computed L/U entry is checked via `std::isfinite()` after the update. If blowup is detected, the entry is reset to its initial-guess value (the scaled matrix entry), preventing corruption from propagating through subsequent sweeps.

- **Removed redundant CSC build**: The CSC structure for U was being built twice before the first sweep (once in `build_ucsc()` called standalone, then again inside the sweep loop at `sweep==0`). The standalone call is removed.

#### 4. Updated defaults

| Parameter | Old default | New default | Rationale |
|-----------|------------|-------------|-----------|
| `sweeps`  | 2          | 5           | 5 sweeps needed for hard problems; minimal cost overhead for easy ones |
| `omega`   | (N/A)      | 0.8         | Stabilizes non-diagonally-dominant matrices; <5% impact on easy problems |
| `symmetric_scaling` | (N/A) | false | Backward compatibility; user can enable for better convergence |

### **Files modified**

- `amgcl/relaxation/ilu0_chow_patel.hpp` — Main implementation (also author attribution update)
- `amgcl/mpi/relaxation/ilu0_chow_patel.hpp` — Author attribution update

### **✅ Validation**

1. **Unit tests**: `test_solver_builtin` and `test_solver_block_crs` pass without modification.

2. **Easy problem (3D Poisson, 32³ = 32768 unknowns)**:
   - Standard ILU(0): 25 iterations
   - Chow-Patel (new defaults): 26 iterations (+4% overhead — negligible)

3. **Hard problem (595,900 unknowns, 70 nnz/row avg, non-symmetric, non-diagonally-dominant, Jacobian norm bound ≈ 35)**:
   - Standard ILU(0): 9 iterations (sequential factorization)
   - Chow-Patel (old code, omega=1, 2 sweeps): **NaN after 1 iteration** ✗
   - Chow-Patel (new defaults, omega=0.8, 5 sweeps): **269 iterations** ✓
   - Chow-Patel (omega=0.8, 5 sweeps, symmetric_scaling=1): **214 iterations** ✓

4. **Block matrix support**: Confirmed compilation and tests pass with `static_matrix<double,4,4>` value type (the `operator*` ordering is compatible with block types).

**NOTE**: The hard problem from point 3 is the one mentioned in the comments from https://github.com/ddemidov/amgcl/pull/307.

### **Backward compatibility**

- The `omega=0.8` default is slightly different from an implicit `omega=1.0` in the original code. For well-conditioned matrices, the impact is minimal (1–2 extra solver iterations at most). Users who relied on the old behavior can set `precond.omega=1.0` explicitly.
- The `sweeps` default change from 2 to 5 increases factorization setup time but improves preconditioner quality. Users can restore old behavior with `precond.sweeps=2`.
- `symmetric_scaling=false` by default preserves the original row-scaling behavior.

## **🆕 Changelog**

- [Enhanced `ilu0_chow_patel` preconditioner with underrelaxation (`omega`), symmetric scaling option, NaN protection, and improved pivot guards to support non-diagonally-dominant matrices that previously caused divergence](https://github.com/ddemidov/amgcl/commit/83a496b572d07c567c0824a280f73dfae780f4ee)
- [Update author information in ILU(0) Chow-Patel header files](https://github.com/ddemidov/amgcl/commit/dc03a005827011e2cbd0bc95213a3c1128f85194)
- [Add zero pivot guard in ILU(0) Chow-Patel factorization](https://github.com/ddemidov/amgcl/commit/25ed9f1dfe0d89ef13f7699be86e6bec76945c59)
- [Fix zero pivot handling in ILU(0) Chow-Patel factorization](https://github.com/ddemidov/amgcl/commit/15a7cd7f42db68ffb4bc7efc6427e3abb20089c2)
