### PR TITLE
Reuse cuSPARSE SpMV preprocessing in CUDA CSR backend

### DIFF
--- a/amgcl/backend/cuda.hpp
+++ b/amgcl/backend/cuda.hpp
@@ -45,6 +45,8 @@ THE SOFTWARE.
 #include <thrust/scatter.h>
 #include <thrust/for_each.h>
 #include <thrust/inner_product.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/tuple.h>
 #include <cusparse_v2.h>
 
 namespace amgcl {
@@ -269,6 +271,7 @@ class cuda_matrix {
                 if (buf.size() < buf_size)
                     buf.resize(buf_size);
 
+#if CUDART_VERSION >= 12040
                 AMGCL_CALL_CUDA(
                         cusparseSpMV_preprocess(
                             handle,
@@ -283,6 +286,7 @@ class cuda_matrix {
                             thrust::raw_pointer_cast(&buf[0])
                             )
                         );
+#endif
 
                 ready_for_spmv = true;
             }

--- a/amgcl/backend/cuda.hpp
+++ b/amgcl/backend/cuda.hpp
@@ -248,24 +248,44 @@ class cuda_matrix {
                     backend::detail::cuda_deleter()
                     );
 
-            size_t buf_size;
-            AMGCL_CALL_CUDA(
-                    cusparseSpMV_bufferSize(
-                        handle,
-                        CUSPARSE_OPERATION_NON_TRANSPOSE,
-                        &alpha,
-                        desc.get(),
-                        xdesc.get(),
-                        &beta,
-                        ydesc.get(),
-                        detail::cuda_datatype<real>(),
-                        CUSPARSE_SPMV_CSR_ALG1,
-                        &buf_size
-                        )
-                    );
+            if (!ready_for_spmv) {
+                size_t buf_size;
 
-            if (buf.size() < buf_size)
-                buf.resize(buf_size);
+                AMGCL_CALL_CUDA(
+                        cusparseSpMV_bufferSize(
+                            handle,
+                            CUSPARSE_OPERATION_NON_TRANSPOSE,
+                            &alpha,
+                            desc.get(),
+                            xdesc.get(),
+                            &beta,
+                            ydesc.get(),
+                            detail::cuda_datatype<real>(),
+                            CUSPARSE_SPMV_CSR_ALG1,
+                            &buf_size
+                            )
+                        );
+
+                if (buf.size() < buf_size)
+                    buf.resize(buf_size);
+
+                AMGCL_CALL_CUDA(
+                        cusparseSpMV_preprocess(
+                            handle,
+                            CUSPARSE_OPERATION_NON_TRANSPOSE,
+                            &alpha,
+                            desc.get(),
+                            xdesc.get(),
+                            &beta,
+                            ydesc.get(),
+                            detail::cuda_datatype<real>(),
+                            CUSPARSE_SPMV_CSR_ALG1,
+                            thrust::raw_pointer_cast(&buf[0])
+                            )
+                        );
+
+                ready_for_spmv = true;
+            }
 
             AMGCL_CALL_CUDA(
                     cusparseSpMV(
@@ -304,6 +324,7 @@ class cuda_matrix {
         thrust::device_vector<real> val;
 
         mutable thrust::device_vector<char> buf;
+        mutable bool ready_for_spmv = false;
 
 };
 


### PR DESCRIPTION
## Summary

This PR reuses cuSPARSE SpMV preprocessing in the CUDA CSR backend.

The current CUDA CSR SpMV path repeatedly prepares the cuSPARSE SpMV call for the same matrix. In iterative solves, the same CSR matrix is used for many SpMV calls, so this repeated preparation can be avoided.

This change prepares the SpMV workspace once for a `cuda_matrix`. When `cusparseSpMV_preprocess()` is available, it is called once after the external buffer is allocated, and the prepared state is reused for later `cusparseSpMV()` calls.

The mathematical SpMV operation is unchanged.

## What changed

- Cache the CUDA CSR SpMV preparation state inside `cuda_matrix`.
- Call `cusparseSpMV_bufferSize()` and resize the external buffer before the first SpMV.
- Call `cusparseSpMV_preprocess()` once after the buffer has been allocated when the CUDA/cuSPARSE version provides it.
- Reuse the same cuSPARSE matrix descriptor, dense vector descriptors, algorithm, and external buffer for later SpMV calls.
- Add explicit Thrust headers for `make_zip_iterator()` and `make_tuple()` with newer Thrust versions.

## Why

This targets repeated SpMV workflows, such as AMG-preconditioned Krylov solves, where the same CSR matrix is used many times.

The optimization is not intended to make the cuSPARSE `csrmv` kernel itself faster. It removes repeated cuSPARSE CSR partition/preprocessing work around repeated SpMV calls.

## Benchmark

Benchmark target:

- `examples/solver_cuda -n N`
- generated 3D Poisson problem
- CUDA backend
- baseline: upstream/master build
- proposed: this PR build
- sizes: `n = 128 ... 224`
- problem size: 2.1M to 11.2M unknowns
- level-0 nnz: 14.6M to 78.4M

Raw timing points use the median of 5 unprofiled runs with p25-p75 error bars. Nsight Systems is used separately to inspect kernel/API behavior and is not used as the source of end-to-end timing.

Full CSV and benchmark notes:

- CSV: https://raw.githubusercontent.com/LwhJesse/amgcl/benchmark-artifacts/cuda-spmv-preprocess/pr_scale_solver.csv
- Notes: https://raw.githubusercontent.com/LwhJesse/amgcl/benchmark-artifacts/cuda-spmv-preprocess/README.md

## Environment

Local benchmark environment:

- GPU: NVIDIA GeForce RTX 4060 Laptop GPU
- Build type: Release
- CUDA toolchain used locally: nvcc 13.2
- Host compiler: g++-15
- Profiler: Nsight Systems

### CSR partition kernel launches

Nsight Systems shows that `csr_partition_kernel` launches are reduced by about 97-98% across the tested problem sizes.

![CSR partition kernel launches](https://raw.githubusercontent.com/LwhJesse/amgcl/benchmark-artifacts/cuda-spmv-preprocess/01_csr_partition_kernel_launches.png)

### CSR partition kernel total time

The accumulated `csr_partition_kernel` time is also reduced by about 97-98%.

![CSR partition kernel time](https://raw.githubusercontent.com/LwhJesse/amgcl/benchmark-artifacts/cuda-spmv-preprocess/02_csr_partition_kernel_time_ms.png)

### Solve time

The solve phase shows a small but consistent improvement across the tested problem sizes. In this scaling test, solve-time improvement is about 0.6-1.5%.

![Solve time](https://raw.githubusercontent.com/LwhJesse/amgcl/benchmark-artifacts/cuda-spmv-preprocess/03_solve_time_s.png)

### CUDA launch overhead

The total `cudaLaunchKernel` time is also lower in the proposed version, consistent with removing repeated partition/preprocessing launches.

![CUDA launch overhead](https://raw.githubusercontent.com/LwhJesse/amgcl/benchmark-artifacts/cuda-spmv-preprocess/05_cudaLaunchKernel_total_time_ms.png)

## Notes

Total `Profile` time is roughly neutral in this benchmark because the full run includes AMG setup and other phases that dominate the overall runtime. The targeted effect is visible in the repeated SpMV path: CSR partition/preprocessing launches are removed, CUDA launch overhead is reduced, and solve time shows a small consistent improvement.

## Testing

Built and tested locally with the CUDA example build.

Preflight:

- `git diff --check -- amgcl/backend/cuda.hpp`
- `cmake --build build-cuda-current-gcc15 -j$(nproc)`
- `./build-cuda-current-gcc15/examples/solver_cuda -n 128`

Main scaling benchmark:

- `examples/solver_cuda -n N`, `N = 128 ... 224`

Additional local CUDA smoke/performance cases were run during validation:

- `tutorial/1.poisson3Db/poisson3Db_cuda`
- `examples/schur_pressure_correction_cuda`
- `examples/cpr_drs_cuda`
