### PR TITLE
[ROCm] Add a native hipSPARSE backend for AMD GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,29 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 endif()
 
 #----------------------------------------------------------------------------
+# Find HIP (ROCm/AMD GPU backend)
+#----------------------------------------------------------------------------
+option(USE_HIP "Build the ROCm/HIP backend (hipSPARSE + rocThrust)" OFF)
+if (USE_HIP)
+    # Do not hardcode the arch: a literal here would override
+    # -DCMAKE_HIP_ARCHITECTURES and force every target arch to edit this
+    # file to build. Default the arch only when unset.
+    if (NOT DEFINED CMAKE_HIP_ARCHITECTURES OR CMAKE_HIP_ARCHITECTURES STREQUAL "")
+        set(CMAKE_HIP_ARCHITECTURES "gfx90a")
+    endif()
+
+    enable_language(HIP)
+
+    find_package(hipsparse REQUIRED)
+    find_package(rocsparse REQUIRED)
+
+    add_library(hip_target INTERFACE)
+    target_link_libraries(hip_target INTERFACE amgcl roc::hipsparse roc::rocsparse)
+    # rocThrust/rocPRIM/hipCUB hard-#error below C++17.
+    target_compile_features(hip_target INTERFACE cxx_std_17)
+endif()
+
+#----------------------------------------------------------------------------
 # Find MPI
 #----------------------------------------------------------------------------
 find_package(MPI 3.0)

--- a/amgcl/backend/hip.hpp
+++ b/amgcl/backend/hip.hpp
@@ -5,6 +5,7 @@
 The MIT License
 
 Copyright (c) 2012-2022 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2026 Advanced Micro Devices, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +29,7 @@ THE SOFTWARE.
 /**
  * \file   amgcl/backend/hip.hpp
  * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \author Jeff Daily <jeff.daily@amd.com>
  * \brief  ROCm/HIP backend.
  *
  * AMD GPU mirror of backend/cuda.hpp. Uses hipSPARSE (the cuSPARSE-compatible

--- a/amgcl/backend/hip.hpp
+++ b/amgcl/backend/hip.hpp
@@ -1,0 +1,711 @@
+#ifndef AMGCL_BACKEND_HIP_HPP
+#define AMGCL_BACKEND_HIP_HPP
+
+/*
+The MIT License
+
+Copyright (c) 2012-2022 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * \file   amgcl/backend/hip.hpp
+ * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \brief  ROCm/HIP backend.
+ *
+ * AMD GPU mirror of backend/cuda.hpp. Uses hipSPARSE (the cuSPARSE-compatible
+ * ROCm interface) for the CSR SpMV and rocThrust for the dense vector kernels.
+ * hipSPARSE exposes the same generic SpMV API as cuSPARSE, so this header
+ * follows the CUDA backend structure with only the cusparse->hipsparse symbol
+ * swap; rocThrust shares the thrust:: API and header paths, so the Thrust code
+ * is unchanged.
+ */
+
+#include <type_traits>
+#include <memory>
+
+#include <amgcl/backend/builtin.hpp>
+#include <amgcl/solver/skyline_lu.hpp>
+#include <amgcl/util.hpp>
+
+#include <thrust/device_vector.h>
+#include <thrust/fill.h>
+#include <thrust/copy.h>
+#include <thrust/gather.h>
+#include <thrust/scatter.h>
+#include <thrust/for_each.h>
+#include <thrust/inner_product.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/tuple.h>
+
+#include <hip/hip_runtime.h>
+#include <hip/library_types.h>
+#include <hipsparse/hipsparse.h>
+
+namespace amgcl {
+
+namespace solver {
+
+/** Wrapper around solver::skyline_lu for use with the HIP backend.
+ * Copies the rhs to the host memory, solves the problem using the host CPU,
+ * then copies the solution back to the compute device(s).
+ */
+template <class T>
+struct hip_skyline_lu : solver::skyline_lu<T> {
+    typedef solver::skyline_lu<T> Base;
+
+    mutable std::vector<T> _rhs, _x;
+
+    template <class Matrix, class Params>
+    hip_skyline_lu(const Matrix &A, const Params&)
+        : Base(*A), _rhs(backend::rows(*A)), _x(backend::rows(*A))
+    { }
+
+    template <class Vec1, class Vec2>
+    void operator()(const Vec1 &rhs, Vec2 &x) const {
+        thrust::copy(rhs.begin(), rhs.end(), _rhs.begin());
+        static_cast<const Base*>(this)->operator()(_rhs, _x);
+        thrust::copy(_x.begin(), _x.end(), x.begin());
+    }
+
+    size_t bytes() const {
+        return
+            backend::bytes(*static_cast<const Base*>(this)) +
+            backend::bytes(_rhs) +
+            backend::bytes(_x);
+    }
+};
+
+}
+
+namespace backend {
+namespace detail {
+
+inline void hip_check(hipsparseStatus_t rc, const char *file, int line) {
+    if (rc != HIPSPARSE_STATUS_SUCCESS) {
+        std::ostringstream msg;
+        msg << "HIP error " << rc << " at \"" << file << ":" << line;
+        precondition(false, msg.str());
+    }
+}
+
+inline void hip_check(hipError_t rc, const char *file, int line) {
+    if (rc != hipSuccess) {
+        std::ostringstream msg;
+        msg << "HIP error " << rc << " at \"" << file << ":" << line;
+        precondition(false, msg.str());
+    }
+}
+
+#define AMGCL_CALL_HIP(rc)                                                     \
+    amgcl::backend::detail::hip_check(rc, __FILE__, __LINE__)
+
+struct hip_deleter {
+    // hipsparseMatDescr_t and hipsparseDnVecDescr_t are both typedef'd to void*
+    // in hipSPARSE (unlike cuSPARSE, where they are distinct struct pointers),
+    // so they cannot be told apart by overload. The legacy hipsparseMatDescr_t
+    // (used only by the ILU0 relaxation) gets its own deleter there; here the
+    // void* overload destroys a dense-vector descriptor.
+    void operator()(hipsparseSpMatDescr_t handle) {
+        AMGCL_CALL_HIP( hipsparseDestroySpMat(handle) );
+    }
+
+    void operator()(hipsparseDnVecDescr_t handle) {
+        AMGCL_CALL_HIP( hipsparseDestroyDnVec(handle) );
+    }
+
+    void operator()(hipEvent_t handle) {
+        AMGCL_CALL_HIP( hipEventDestroy(handle) );
+    }
+
+    void operator()(csrilu02Info_t handle) {
+        AMGCL_CALL_HIP( hipsparseDestroyCsrilu02Info(handle) );
+    }
+
+    void operator()(hipsparseSpSVDescr_t handle) {
+        AMGCL_CALL_HIP( hipsparseSpSV_destroyDescr(handle) );
+    }
+};
+
+
+template <typename real>
+hipDataType hip_datatype() {
+    if (sizeof(real) == sizeof(float))
+        return HIP_R_32F;
+    else
+        return HIP_R_64F;
+}
+
+template <typename real>
+hipsparseDnVecDescr_t hip_vector_description(thrust::device_vector<real> &x) {
+    hipsparseDnVecDescr_t desc;
+    AMGCL_CALL_HIP(
+            hipsparseCreateDnVec(
+                &desc,
+                x.size(),
+                thrust::raw_pointer_cast(&x[0]),
+                hip_datatype<real>()
+                )
+            );
+    return desc;
+}
+
+template <typename real>
+hipsparseDnVecDescr_t hip_vector_description(const thrust::device_vector<real> &&x) {
+    hipsparseDnVecDescr_t desc;
+    AMGCL_CALL_HIP(
+            hipsparseCreateDnVec(
+                &desc,
+                x.size(),
+                thrust::raw_pointer_cast(&x[0]),
+                hip_datatype<real>()
+                )
+            );
+    return desc;
+}
+
+template <typename real>
+hipsparseSpMatDescr_t hip_matrix_description(
+        size_t nrows,
+        size_t ncols,
+        size_t nnz,
+        thrust::device_vector<int> &ptr,
+        thrust::device_vector<int> &col,
+        thrust::device_vector<real> &val
+        )
+{
+    hipsparseSpMatDescr_t desc;
+    AMGCL_CALL_HIP(
+            hipsparseCreateCsr(
+                &desc,
+                nrows,
+                ncols,
+                nnz,
+                thrust::raw_pointer_cast(&ptr[0]),
+                thrust::raw_pointer_cast(&col[0]),
+                thrust::raw_pointer_cast(&val[0]),
+                HIPSPARSE_INDEX_32I,
+                HIPSPARSE_INDEX_32I,
+                HIPSPARSE_INDEX_BASE_ZERO,
+                detail::hip_datatype<real>()
+                )
+            );
+    return desc;
+}
+
+} // namespace detail
+
+/// hipSPARSE matrix in CSR format.
+template <typename real>
+class hip_matrix {
+    public:
+        typedef real value_type;
+
+        hip_matrix(
+                size_t n, size_t m,
+                const ptrdiff_t *p_ptr,
+                const ptrdiff_t *p_col,
+                const real      *p_val,
+                hipsparseHandle_t handle
+                )
+            : nrows(n), ncols(m), nnz(p_ptr[n]), handle(handle),
+              ptr(p_ptr, p_ptr + n + 1), col(p_col, p_col + nnz), val(p_val, p_val + nnz)
+        {
+              desc.reset(
+                      detail::hip_matrix_description(nrows, ncols, nnz, ptr, col, val),
+                      backend::detail::hip_deleter()
+                      );
+        }
+
+        void spmv(
+                real alpha, thrust::device_vector<real> const &x,
+                real beta,  thrust::device_vector<real>       &y
+            ) const
+        {
+            std::shared_ptr<std::remove_pointer<hipsparseDnVecDescr_t>::type> xdesc(
+                    detail::hip_vector_description(const_cast<thrust::device_vector<real>&>(x)),
+                    backend::detail::hip_deleter()
+                    );
+            std::shared_ptr<std::remove_pointer<hipsparseDnVecDescr_t>::type> ydesc(
+                    detail::hip_vector_description(y),
+                    backend::detail::hip_deleter()
+                    );
+
+            if (!ready_for_spmv) {
+                size_t buf_size;
+
+                AMGCL_CALL_HIP(
+                        hipsparseSpMV_bufferSize(
+                            handle,
+                            HIPSPARSE_OPERATION_NON_TRANSPOSE,
+                            &alpha,
+                            desc.get(),
+                            xdesc.get(),
+                            &beta,
+                            ydesc.get(),
+                            detail::hip_datatype<real>(),
+                            HIPSPARSE_SPMV_CSR_ALG1,
+                            &buf_size
+                            )
+                        );
+
+                if (buf.size() < buf_size)
+                    buf.resize(buf_size);
+
+                AMGCL_CALL_HIP(
+                        hipsparseSpMV_preprocess(
+                            handle,
+                            HIPSPARSE_OPERATION_NON_TRANSPOSE,
+                            &alpha,
+                            desc.get(),
+                            xdesc.get(),
+                            &beta,
+                            ydesc.get(),
+                            detail::hip_datatype<real>(),
+                            HIPSPARSE_SPMV_CSR_ALG1,
+                            thrust::raw_pointer_cast(&buf[0])
+                            )
+                        );
+
+                ready_for_spmv = true;
+            }
+
+            AMGCL_CALL_HIP(
+                    hipsparseSpMV(
+                        handle,
+                        HIPSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        desc.get(),
+                        xdesc.get(),
+                        &beta,
+                        ydesc.get(),
+                        detail::hip_datatype<real>(),
+                        HIPSPARSE_SPMV_CSR_ALG1,
+                        thrust::raw_pointer_cast(&buf[0])
+                        )
+                    );
+        }
+
+        size_t rows()     const { return nrows; }
+        size_t cols()     const { return ncols; }
+        size_t nonzeros() const { return nnz;   }
+        size_t bytes()    const {
+            return
+                sizeof(int)  * (nrows + 1) +
+                sizeof(int)  * nnz +
+                sizeof(real) * nnz;
+        }
+    private:
+        size_t nrows, ncols, nnz;
+
+        hipsparseHandle_t handle;
+
+        std::shared_ptr<std::remove_pointer<hipsparseSpMatDescr_t>::type> desc;
+
+        thrust::device_vector<int>  ptr;
+        thrust::device_vector<int>  col;
+        thrust::device_vector<real> val;
+
+        mutable thrust::device_vector<char> buf;
+        mutable bool ready_for_spmv = false;
+
+};
+
+/// ROCm/HIP backend.
+/**
+ * Uses hipSPARSE for matrix operations and Thrust (rocThrust) for vector
+ * operations.
+ *
+ * \param real Value type.
+ * \ingroup backends
+ */
+template <typename real, class DirectSolver = solver::hip_skyline_lu<real> >
+struct hip {
+        static_assert(
+                std::is_same<real, float>::value ||
+                std::is_same<real, double>::value,
+                "Unsupported value type for hip backend"
+                );
+
+    typedef real value_type;
+    typedef ptrdiff_t col_type;
+    typedef ptrdiff_t ptr_type;
+    typedef hip_matrix<real>        matrix;
+    typedef thrust::device_vector<real> vector;
+    typedef thrust::device_vector<real> matrix_diagonal;
+    typedef DirectSolver                direct_solver;
+
+    struct provides_row_iterator : std::false_type {};
+
+    /// Backend parameters.
+    struct params {
+        /// hipSPARSE handle.
+        hipsparseHandle_t hipsparse_handle;
+
+        params(hipsparseHandle_t handle = 0) : hipsparse_handle(handle) {}
+
+#ifndef AMGCL_NO_BOOST
+        params(const boost::property_tree::ptree &p)
+            : AMGCL_PARAMS_IMPORT_VALUE(p, hipsparse_handle)
+        {
+            check_params(p, {"hipsparse_handle"});
+        }
+
+        void get(boost::property_tree::ptree &p, const std::string &path) const {
+            AMGCL_PARAMS_EXPORT_VALUE(p, path, hipsparse_handle);
+        }
+#endif
+    };
+
+    static std::string name() { return "hip"; }
+
+    /// Copy matrix from builtin backend.
+    static std::shared_ptr<matrix>
+    copy_matrix(std::shared_ptr< typename builtin<real>::matrix > A, const params &prm)
+    {
+        return std::make_shared<matrix>(rows(*A), cols(*A),
+                A->ptr, A->col, A->val, prm.hipsparse_handle
+                );
+    }
+
+    /// Copy vector from builtin backend.
+    static std::shared_ptr<vector>
+    copy_vector(typename builtin<real>::vector const &x, const params&)
+    {
+        return std::make_shared<vector>(x.data(), x.data() + x.size());
+    }
+
+    /// Copy vector from builtin backend.
+    static std::shared_ptr<vector>
+    copy_vector(std::shared_ptr< typename builtin<real>::vector > x, const params &prm)
+    {
+        return copy_vector(*x, prm);
+    }
+
+    /// Create vector of the specified size.
+    static std::shared_ptr<vector>
+    create_vector(size_t size, const params&)
+    {
+        return std::make_shared<vector>(size);
+    }
+
+    /// Create direct solver for coarse level
+    static std::shared_ptr<direct_solver>
+    create_solver(std::shared_ptr< typename builtin<real>::matrix > A, const params &prm)
+    {
+        return std::make_shared<direct_solver>(A, prm);
+    }
+
+    struct gather {
+        thrust::device_vector<ptrdiff_t>  I;
+        mutable thrust::device_vector<value_type> T;
+
+        gather(size_t src_size, const std::vector<ptrdiff_t> &I, const params&)
+            : I(I), T(I.size())
+        { }
+
+        void operator()(const vector &src, vector &dst) const {
+            thrust::gather(I.begin(), I.end(), src.begin(), dst.begin());
+        }
+
+        void operator()(const vector &vec, std::vector<value_type> &vals) const {
+            thrust::gather(I.begin(), I.end(), vec.begin(), T.begin());
+            thrust::copy(T.begin(), T.end(), vals.begin());
+        }
+    };
+
+    struct scatter {
+        thrust::device_vector<ptrdiff_t>  I;
+
+        scatter(size_t size, const std::vector<ptrdiff_t> &I, const params &)
+            : I(I)
+        { }
+
+        void operator()(const vector &src, vector &dst) const {
+            thrust::scatter(src.begin(), src.end(), I.begin(), dst.begin());
+        }
+    };
+};
+
+//---------------------------------------------------------------------------
+// Backend interface implementation
+//---------------------------------------------------------------------------
+template < typename V >
+struct bytes_impl< thrust::device_vector<V> > {
+    static size_t get(const thrust::device_vector<V> &v) {
+        return v.size() * sizeof(V);
+    }
+};
+
+template < typename Alpha, typename Beta, typename V >
+struct spmv_impl<
+    Alpha, hip_matrix<V>, thrust::device_vector<V>,
+    Beta,  thrust::device_vector<V>
+    >
+{
+    typedef hip_matrix<V> matrix;
+    typedef thrust::device_vector<V> vector;
+
+    static void apply(Alpha alpha, const matrix &A, const vector &x,
+            Beta beta, vector &y)
+    {
+        A.spmv(alpha, x, beta, y);
+    }
+};
+
+template < typename V >
+struct residual_impl<
+    hip_matrix<V>,
+    thrust::device_vector<V>,
+    thrust::device_vector<V>,
+    thrust::device_vector<V>
+    >
+{
+    typedef hip_matrix<V> matrix;
+    typedef thrust::device_vector<V> vector;
+
+    static void apply(const vector &rhs, const matrix &A, const vector &x,
+            vector &r)
+    {
+        thrust::copy(rhs.begin(), rhs.end(), r.begin());
+        A.spmv(-1, x, 1, r);
+    }
+};
+
+template < typename V >
+struct clear_impl< thrust::device_vector<V> >
+{
+    typedef thrust::device_vector<V> vector;
+
+    static void apply(vector &x)
+    {
+        thrust::fill(x.begin(), x.end(), V());
+    }
+};
+
+template <class V, class T>
+struct copy_impl<V, thrust::device_vector<T> >
+{
+    static void apply(const V &x, thrust::device_vector<T> &y)
+    {
+        thrust::copy(x.begin(), x.end(), y.begin());
+    }
+};
+
+template <class T, class V>
+struct copy_impl<thrust::device_vector<T>, V >
+{
+    static void apply(const thrust::device_vector<T> &x, V &y)
+    {
+        thrust::copy(x.begin(), x.end(), y.begin());
+    }
+};
+
+template <class T1, class T2>
+struct copy_impl<thrust::device_vector<T1>, thrust::device_vector<T2> >
+{
+    static void apply(const thrust::device_vector<T1> &x, thrust::device_vector<T2> &y)
+    {
+        thrust::copy(x.begin(), x.end(), y.begin());
+    }
+};
+
+template < typename V >
+struct inner_product_impl<
+    thrust::device_vector<V>,
+    thrust::device_vector<V>
+    >
+{
+    typedef thrust::device_vector<V> vector;
+
+    static V get(const vector &x, const vector &y)
+    {
+        return thrust::inner_product(x.begin(), x.end(), y.begin(), V());
+    }
+};
+
+template < typename A, typename B, typename V >
+struct axpby_impl<
+    A, thrust::device_vector<V>,
+    B, thrust::device_vector<V>
+    >
+{
+    typedef thrust::device_vector<V> vector;
+
+    struct functor {
+        A a;
+        B b;
+        functor(A a, B b) : a(a), b(b) {}
+
+        template <class Tuple>
+        __host__ __device__ void operator()( Tuple t ) const {
+            using thrust::get;
+
+            if (b)
+                get<1>(t) = a * get<0>(t) + b * get<1>(t);
+            else
+                get<1>(t) = a * get<0>(t);
+        }
+    };
+
+    static void apply(A a, const vector &x, B b, vector &y)
+    {
+        thrust::for_each(
+                thrust::make_zip_iterator(
+                    thrust::make_tuple(
+                        x.begin(), y.begin()
+                        )
+                    ),
+                thrust::make_zip_iterator(
+                    thrust::make_tuple(
+                        x.end(), y.end()
+                        )
+                    ),
+                functor(a, b)
+                );
+    }
+};
+
+template < typename A, typename B, typename C, typename V >
+struct axpbypcz_impl<
+    A, thrust::device_vector<V>,
+    B, thrust::device_vector<V>,
+    C, thrust::device_vector<V>
+    >
+{
+    typedef thrust::device_vector<V> vector;
+
+    struct functor {
+        A a;
+        B b;
+        C c;
+
+        functor(A a, B b, C c) : a(a), b(b), c(c) {}
+
+        template <class Tuple>
+        __host__ __device__ void operator()( Tuple t ) const {
+            using thrust::get;
+
+            if (c)
+                get<2>(t) = a * get<0>(t) + b * get<1>(t) + c * get<2>(t);
+            else
+                get<2>(t) = a * get<0>(t) + b * get<1>(t);
+        }
+    };
+
+    static void apply(
+            A a, const vector &x,
+            B b, const vector &y,
+            C c,       vector &z
+            )
+    {
+        thrust::for_each(
+                thrust::make_zip_iterator(
+                    thrust::make_tuple(
+                        x.begin(), y.begin(), z.begin()
+                        )
+                    ),
+                thrust::make_zip_iterator(
+                    thrust::make_tuple(
+                        x.end(), y.end(), z.end()
+                        )
+                    ),
+                functor(a, b, c)
+                );
+    }
+};
+
+template < typename A, typename B, typename V >
+struct vmul_impl<
+    A, thrust::device_vector<V>, thrust::device_vector<V>,
+    B, thrust::device_vector<V>
+    >
+{
+    typedef thrust::device_vector<V> vector;
+
+    struct functor {
+        A a;
+        B b;
+        functor(A a, B b) : a(a), b(b) {}
+
+        template <class Tuple>
+        __host__ __device__ void operator()( Tuple t ) const {
+            using thrust::get;
+
+            if (b)
+                get<2>(t) = a * get<0>(t) * get<1>(t) + b * get<2>(t);
+            else
+                get<2>(t) = a * get<0>(t) * get<1>(t);
+        }
+    };
+
+    static void apply(A a, const vector &x, const vector &y, B b, vector &z)
+    {
+        thrust::for_each(
+                thrust::make_zip_iterator(
+                    thrust::make_tuple(
+                        x.begin(), y.begin(), z.begin()
+                        )
+                    ),
+                thrust::make_zip_iterator(
+                    thrust::make_tuple(
+                        x.end(), y.end(), z.end()
+                        )
+                    ),
+                functor(a, b)
+                );
+    }
+};
+
+class hip_event {
+    public:
+        hip_event() : e(create_event(), backend::detail::hip_deleter()) { }
+
+        float operator-(hip_event tic) const {
+            float delta;
+            AMGCL_CALL_HIP( hipEventSynchronize(e.get()) );
+            AMGCL_CALL_HIP( hipEventElapsedTime(&delta, tic.e.get(), e.get()) );
+            return delta / 1000.0f;
+        }
+    private:
+        std::shared_ptr<std::remove_pointer<hipEvent_t>::type> e;
+
+        static hipEvent_t create_event() {
+            hipEvent_t e;
+            AMGCL_CALL_HIP( hipEventCreate(&e) );
+            AMGCL_CALL_HIP( hipEventRecord(e, 0) );
+            return e;
+        }
+};
+
+struct hip_clock {
+    typedef hip_event value_type;
+
+    static const char* units() { return "s"; }
+
+    hip_event current() const {
+        return hip_event();
+    }
+};
+
+} // namespace backend
+} // namespace amgcl
+
+#endif

--- a/amgcl/relaxation/rocsparse_ilu0.hpp
+++ b/amgcl/relaxation/rocsparse_ilu0.hpp
@@ -5,6 +5,7 @@
 The MIT License
 
 Copyright (c) 2012-2022 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2026 Advanced Micro Devices, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +29,7 @@ THE SOFTWARE.
 /**
  * \file   amgcl/relaxation/rocsparse_ilu0.hpp
  * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \author Jeff Daily <jeff.daily@amd.com>
  * \brief  Implementation of ILU0 smoother for the ROCm/HIP backend.
  *
  * AMD GPU mirror of relaxation/cusparse_ilu0.hpp. Uses hipSPARSE (the

--- a/amgcl/relaxation/rocsparse_ilu0.hpp
+++ b/amgcl/relaxation/rocsparse_ilu0.hpp
@@ -1,0 +1,493 @@
+#ifndef AMGCL_RELAXATION_ROCSPARSE_ILU0_HPP
+#define AMGCL_RELAXATION_ROCSPARSE_ILU0_HPP
+
+/*
+The MIT License
+
+Copyright (c) 2012-2022 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * \file   amgcl/relaxation/rocsparse_ilu0.hpp
+ * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \brief  Implementation of ILU0 smoother for the ROCm/HIP backend.
+ *
+ * AMD GPU mirror of relaxation/cusparse_ilu0.hpp. Uses hipSPARSE (the
+ * cuSPARSE-compatible ROCm interface): the csrilu02 incomplete-LU
+ * factorization plus the generic SpSV triangular solves, with the same
+ * persistent SpSV descriptor model as cuSPARSE.
+ */
+
+#include <type_traits>
+
+#include <thrust/device_vector.h>
+
+#include <hip/library_types.h>
+#include <hipsparse/hipsparse.h>
+
+#include <amgcl/backend/hip.hpp>
+
+namespace amgcl {
+namespace relaxation {
+
+namespace detail {
+
+// hipsparseMatDescr_t is typedef void* in hipSPARSE and collides with the
+// dense-vector descriptor handled by backend::detail::hip_deleter, so the
+// legacy CSR matrix descriptor used below gets its own deleter.
+struct hip_mat_descr_deleter {
+    void operator()(hipsparseMatDescr_t handle) {
+        AMGCL_CALL_HIP( hipsparseDestroyMatDescr(handle) );
+    }
+};
+
+} // namespace detail
+
+template <class Backend> struct ilu0;
+
+template <typename real>
+struct ilu0< backend::hip<real> > {
+    typedef real value_type;
+    typedef backend::hip<real> Backend;
+
+    struct params {
+        /// Damping factor.
+        float damping;
+
+        params() : damping(1) {}
+
+#ifndef AMGCL_NO_BOOST
+        params(const boost::property_tree::ptree &p)
+            : AMGCL_PARAMS_IMPORT_VALUE(p, damping)
+        {
+            check_params(p, {"damping"});
+        }
+
+        void get(boost::property_tree::ptree &p, const std::string &path) const {
+            AMGCL_PARAMS_EXPORT_VALUE(p, path, damping);
+        }
+#endif
+    } prm;
+
+    /// \copydoc amgcl::relaxation::damped_jacobi::damped_jacobi
+    template <class Matrix>
+    ilu0( const Matrix &A, const params &prm, const typename Backend::params &bprm)
+        : prm(prm), handle(bprm.hipsparse_handle),
+          n(backend::rows(A)), nnz(backend::nonzeros(A)),
+          ptr(A.ptr, A.ptr + n+1),
+          col(A.col, A.col + nnz),
+          val(A.val, A.val + nnz),
+          y(n)
+    {
+        // LU decomposition
+        std::shared_ptr<std::remove_pointer<hipsparseMatDescr_t>::type> descr_M;
+        std::shared_ptr<std::remove_pointer<csrilu02Info_t>::type> info_M;
+
+        {
+            hipsparseMatDescr_t descr;
+            csrilu02Info_t info;
+
+            AMGCL_CALL_HIP( hipsparseCreateMatDescr(&descr) );
+            AMGCL_CALL_HIP( hipsparseSetMatIndexBase(descr, HIPSPARSE_INDEX_BASE_ZERO) );
+            AMGCL_CALL_HIP( hipsparseSetMatType(descr, HIPSPARSE_MATRIX_TYPE_GENERAL) );
+
+            AMGCL_CALL_HIP( hipsparseCreateCsrilu02Info(&info) );
+
+            descr_M.reset(descr, detail::hip_mat_descr_deleter());
+            info_M.reset(info, backend::detail::hip_deleter());
+
+            int buf_size;
+
+            AMGCL_CALL_HIP(
+                    hipsparseXcsrilu02_bufferSize(
+                        handle, n, nnz, descr_M.get(),
+                        thrust::raw_pointer_cast(&val[0]),
+                        thrust::raw_pointer_cast(&ptr[0]),
+                        thrust::raw_pointer_cast(&col[0]),
+                        info_M.get(), &buf_size
+                        )
+                    );
+
+            thrust::device_vector<char> bufLU(buf_size);
+
+            // Analysis and incomplete factorization of the system matrix.
+            int structural_zero;
+            int numerical_zero;
+
+            AMGCL_CALL_HIP(
+                    hipsparseXcsrilu02_analysis(
+                        handle,
+                        n,
+                        nnz,
+                        descr_M.get(),
+                        thrust::raw_pointer_cast(&val[0]),
+                        thrust::raw_pointer_cast(&ptr[0]),
+                        thrust::raw_pointer_cast(&col[0]),
+                        info_M.get(),
+                        HIPSPARSE_SOLVE_POLICY_USE_LEVEL,
+                        thrust::raw_pointer_cast(&bufLU[0])
+                        )
+                    );
+
+            precondition(
+                    HIPSPARSE_STATUS_ZERO_PIVOT != hipsparseXcsrilu02_zeroPivot(handle, info_M.get(), &structural_zero),
+                    "Zero pivot in hipSPARSE ILU0"
+                    );
+
+            AMGCL_CALL_HIP(
+                    hipsparseXcsrilu02(
+                        handle,
+                        n,
+                        nnz,
+                        descr_M.get(),
+                        thrust::raw_pointer_cast(&val[0]),
+                        thrust::raw_pointer_cast(&ptr[0]),
+                        thrust::raw_pointer_cast(&col[0]),
+                        info_M.get(),
+                        HIPSPARSE_SOLVE_POLICY_USE_LEVEL,
+                        thrust::raw_pointer_cast(&bufLU[0])
+                        )
+                    );
+            precondition(
+                    HIPSPARSE_STATUS_ZERO_PIVOT != hipsparseXcsrilu02_zeroPivot(handle, info_M.get(), &numerical_zero),
+                    "Zero pivot in hipSPARSE ILU0"
+                    );
+
+        }
+
+        // Triangular solvers
+        const real alpha = 1;
+        thrust::device_vector<value_type> t(n);
+
+        descr_y.reset(
+                backend::detail::hip_vector_description(y),
+                backend::detail::hip_deleter()
+                );
+
+        std::shared_ptr<std::remove_pointer<hipsparseDnVecDescr_t>::type> descr_t(
+                backend::detail::hip_vector_description(t),
+                backend::detail::hip_deleter()
+                );
+
+        hipsparseFillMode_t fill_lower    = HIPSPARSE_FILL_MODE_LOWER;
+        hipsparseFillMode_t fill_upper    = HIPSPARSE_FILL_MODE_UPPER;
+        hipsparseDiagType_t diag_unit     = HIPSPARSE_DIAG_TYPE_UNIT;
+        hipsparseDiagType_t diag_non_unit = HIPSPARSE_DIAG_TYPE_NON_UNIT;
+
+        // Triangular solver for L
+        {
+            descr_L.reset(
+                    backend::detail::hip_matrix_description(n, n, nnz, ptr, col, val),
+                    backend::detail::hip_deleter()
+                    );
+
+            AMGCL_CALL_HIP(
+                    hipsparseSpMatSetAttribute(
+                        descr_L.get(),
+                        HIPSPARSE_SPMAT_FILL_MODE,
+                        &fill_lower,
+                        sizeof(fill_lower)
+                        )
+                    );
+
+            AMGCL_CALL_HIP(
+                    hipsparseSpMatSetAttribute(
+                        descr_L.get(),
+                        HIPSPARSE_SPMAT_DIAG_TYPE,
+                        &diag_unit,
+                        sizeof(diag_unit)
+                        )
+                    );
+
+
+            size_t buf_size;
+
+            hipsparseSpSVDescr_t desc;
+            AMGCL_CALL_HIP( hipsparseSpSV_createDescr(&desc) );
+            descr_SL.reset(desc, backend::detail::hip_deleter());
+
+            AMGCL_CALL_HIP(
+                    hipsparseSpSV_bufferSize(
+                        handle,
+                        HIPSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        descr_L.get(),
+                        descr_t.get(),
+                        descr_y.get(),
+                        backend::detail::hip_datatype<real>(),
+                        HIPSPARSE_SPSV_ALG_DEFAULT,
+                        descr_SL.get(),
+                        &buf_size
+                        )
+                    );
+
+            bufL.resize(buf_size);
+
+            AMGCL_CALL_HIP(
+                    hipsparseSpSV_analysis(
+                        handle,
+                        HIPSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        descr_L.get(),
+                        descr_t.get(),
+                        descr_y.get(),
+                        backend::detail::hip_datatype<real>(),
+                        HIPSPARSE_SPSV_ALG_DEFAULT,
+                        descr_SL.get(),
+                        thrust::raw_pointer_cast(&bufL[0])
+                        )
+                    );
+        }
+
+        // Triangular solver for U
+        {
+            descr_U.reset(
+                    backend::detail::hip_matrix_description(n, n, nnz, ptr, col, val),
+                    backend::detail::hip_deleter()
+                    );
+
+            AMGCL_CALL_HIP(
+                    hipsparseSpMatSetAttribute(
+                        descr_U.get(),
+                        HIPSPARSE_SPMAT_FILL_MODE,
+                        &fill_upper,
+                        sizeof(fill_upper)
+                        )
+                    );
+
+            AMGCL_CALL_HIP(
+                    hipsparseSpMatSetAttribute(
+                        descr_U.get(),
+                        HIPSPARSE_SPMAT_DIAG_TYPE,
+                        &diag_non_unit,
+                        sizeof(diag_non_unit)
+                        )
+                    );
+
+
+            size_t buf_size;
+
+            hipsparseSpSVDescr_t desc;
+            AMGCL_CALL_HIP( hipsparseSpSV_createDescr(&desc) );
+            descr_SU.reset(desc, backend::detail::hip_deleter());
+
+            AMGCL_CALL_HIP(
+                    hipsparseSpSV_bufferSize(
+                        handle,
+                        HIPSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        descr_U.get(),
+                        descr_y.get(),
+                        descr_t.get(),
+                        backend::detail::hip_datatype<real>(),
+                        HIPSPARSE_SPSV_ALG_DEFAULT,
+                        descr_SU.get(),
+                        &buf_size
+                        )
+                    );
+
+            bufU.resize(buf_size);
+
+            AMGCL_CALL_HIP(
+                    hipsparseSpSV_analysis(
+                        handle,
+                        HIPSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        descr_U.get(),
+                        descr_y.get(),
+                        descr_t.get(),
+                        backend::detail::hip_datatype<real>(),
+                        HIPSPARSE_SPSV_ALG_DEFAULT,
+                        descr_SU.get(),
+                        thrust::raw_pointer_cast(&bufU[0])
+                        )
+                    );
+        }
+    }
+
+    /// \copydoc amgcl::relaxation::damped_jacobi::apply_pre
+    template <class Matrix, class VectorRHS, class VectorX, class VectorTMP>
+    void apply_pre(
+            const Matrix &A, const VectorRHS &rhs, VectorX &x, VectorTMP &tmp
+            ) const
+    {
+        backend::residual(rhs, A, x, tmp);
+        solve(tmp);
+        backend::axpby(prm.damping, tmp, 1, x);
+    }
+
+    /// \copydoc amgcl::relaxation::damped_jacobi::apply_post
+    template <class Matrix, class VectorRHS, class VectorX, class VectorTMP>
+    void apply_post(
+            const Matrix &A, const VectorRHS &rhs, VectorX &x, VectorTMP &tmp
+            ) const
+    {
+        backend::residual(rhs, A, x, tmp);
+        solve(tmp);
+        backend::axpby(prm.damping, tmp, 1, x);
+    }
+
+    template <class Matrix, class VectorRHS, class VectorX>
+    void apply(const Matrix &A, const VectorRHS &rhs, VectorX &x) const
+    {
+        backend::copy(rhs, x);
+        solve(x);
+    }
+
+    size_t bytes() const {
+        // This is incomplete, as hipsparse structs are opaque.
+        return
+            backend::bytes(ptr) +
+            backend::bytes(col) +
+            backend::bytes(val) +
+            backend::bytes(y) +
+            backend::bytes(bufL) +
+            backend::bytes(bufU)
+            ;
+    }
+
+    private:
+        hipsparseHandle_t handle;
+        int n, nnz;
+
+        thrust::device_vector<int> ptr, col;
+        thrust::device_vector<value_type> val;
+        mutable thrust::device_vector<value_type> y;
+
+        std::shared_ptr<std::remove_pointer<hipsparseSpMatDescr_t>::type> descr_L, descr_U;
+        std::shared_ptr<std::remove_pointer<hipsparseSpSVDescr_t>::type>  descr_SL, descr_SU;
+        std::shared_ptr<std::remove_pointer<hipsparseDnVecDescr_t>::type> descr_y;
+        mutable thrust::device_vector<char> bufL, bufU;
+
+        template <class VectorX>
+        void solve(VectorX &x) const {
+            value_type alpha = 1;
+
+            std::shared_ptr<std::remove_pointer<hipsparseDnVecDescr_t>::type> descr_x(
+                    backend::detail::hip_vector_description(x),
+                    backend::detail::hip_deleter()
+                    );
+
+            // Solve L * y = x
+            AMGCL_CALL_HIP(
+                    hipsparseSpSV_solve(
+                        handle,
+                        HIPSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        descr_L.get(),
+                        descr_x.get(),
+                        descr_y.get(),
+                        backend::detail::hip_datatype<real>(),
+                        HIPSPARSE_SPSV_ALG_DEFAULT,
+                        descr_SL.get()
+                        )
+                    );
+
+            // Solve U * x = y
+            AMGCL_CALL_HIP(
+                    hipsparseSpSV_solve(
+                        handle,
+                        HIPSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        descr_U.get(),
+                        descr_y.get(),
+                        descr_x.get(),
+                        backend::detail::hip_datatype<real>(),
+                        HIPSPARSE_SPSV_ALG_DEFAULT,
+                        descr_SU.get()
+                        )
+                    );
+        }
+
+        // hipSPARSE, like cuSPARSE, only ships type-suffixed csrilu02 routines
+        // (Dcsrilu02/Scsrilu02). These thin overloads dispatch on the value
+        // type so the factorization code above can be written once.
+        static hipsparseStatus_t hipsparseXcsrilu02_bufferSize(
+                hipsparseHandle_t handle, int m, int nnz,
+                const hipsparseMatDescr_t descrA, double *csrSortedValA,
+                const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+                csrilu02Info_t info, int *pBufferSizeInBytes)
+        {
+            return hipsparseDcsrilu02_bufferSize(handle, m, nnz, descrA,
+                csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info,
+                pBufferSizeInBytes);
+        }
+
+        static hipsparseStatus_t hipsparseXcsrilu02_bufferSize(
+                hipsparseHandle_t handle, int m, int nnz,
+                const hipsparseMatDescr_t descrA, float *csrSortedValA,
+                const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+                csrilu02Info_t info, int *pBufferSizeInBytes)
+        {
+            return hipsparseScsrilu02_bufferSize(handle, m, nnz, descrA,
+                csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info,
+                pBufferSizeInBytes);
+        }
+
+        static hipsparseStatus_t hipsparseXcsrilu02_analysis(
+                hipsparseHandle_t handle, int m, int nnz,
+                const hipsparseMatDescr_t descrA, const double *csrSortedValA,
+                const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+                csrilu02Info_t info, hipsparseSolvePolicy_t policy, void *pBuffer)
+        {
+            return hipsparseDcsrilu02_analysis(handle, m, nnz, descrA,
+                csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy,
+                pBuffer);
+        }
+
+        static hipsparseStatus_t hipsparseXcsrilu02_analysis(
+                hipsparseHandle_t handle, int m, int nnz,
+                const hipsparseMatDescr_t descrA, const float *csrSortedValA,
+                const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+                csrilu02Info_t info, hipsparseSolvePolicy_t policy, void *pBuffer)
+        {
+            return hipsparseScsrilu02_analysis(handle, m, nnz, descrA,
+                csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy,
+                pBuffer);
+        }
+
+        static hipsparseStatus_t hipsparseXcsrilu02(
+                hipsparseHandle_t handle, int m, int nnz,
+                const hipsparseMatDescr_t descrA, double *csrSortedValA_valM,
+                const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+                csrilu02Info_t info, hipsparseSolvePolicy_t policy, void *pBuffer)
+        {
+            return hipsparseDcsrilu02(handle, m, nnz, descrA,
+                csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info,
+                policy, pBuffer);
+        }
+
+        static hipsparseStatus_t hipsparseXcsrilu02(
+                hipsparseHandle_t handle, int m, int nnz,
+                const hipsparseMatDescr_t descrA, float *csrSortedValA_valM,
+                const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+                csrilu02Info_t info, hipsparseSolvePolicy_t policy, void *pBuffer)
+        {
+            return hipsparseScsrilu02(handle, m, nnz, descrA,
+                csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info,
+                policy, pBuffer);
+        }
+};
+
+} // namespace relaxation
+} // namespace amgcl
+
+#endif

--- a/docs/components/backends.rst
+++ b/docs/components/backends.rst
@@ -106,6 +106,35 @@ NVIDIA CUDA backend
 .. _nvcc: https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html
 .. _cusparseCreate(): https://docs.nvidia.com/cuda/cusparse/index.html#cusparseCreate
 
+AMD HIP backend
+---------------
+
+.. cpp:class:: template <class ValueType> \
+                amgcl::backend::hip
+
+   Include ``<amgcl/backend/hip.hpp>``.
+
+   The backend uses the AMD ROCm_/HIP_ technology for the parallelization of its
+   primitives on AMD GPUs. It depends on the rocThrust_ and hipSPARSE_ libraries
+   (the HIP analogues of Thrust and cuSPARSE), and the code using the backend has
+   to be compiled with AMD's hipcc_ compiler. The user needs to initialize the
+   hipSPARSE_ library with a call to the `hipsparseCreate()` function and pass the
+   returned handle to AMGCL in the backend parameters.
+
+   .. cpp:class:: params
+
+      The backend parameters
+
+      .. cpp:member:: hipsparseHandle_t hipsparse_handle
+
+         hipSPARSE_ handle created with the `hipsparseCreate()` function.
+
+.. _ROCm: https://rocm.docs.amd.com/
+.. _HIP: https://rocm.docs.amd.com/projects/HIP/
+.. _rocThrust: https://rocm.docs.amd.com/projects/rocThrust/
+.. _hipSPARSE: https://rocm.docs.amd.com/projects/hipSPARSE/
+.. _hipcc: https://rocm.docs.amd.com/projects/HIPCC/
+
 VexCL backend
 -------------
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -124,4 +124,23 @@ if (TARGET cuda_target)
     add_cuda_example(cpr_drs)
 endif()
 
+if (TARGET hip_target)
+    function(add_hip_example example)
+        configure_file(
+            ${CMAKE_CURRENT_SOURCE_DIR}/${example}.cpp
+            ${CMAKE_CURRENT_BINARY_DIR}/${example}.hip
+            COPYONLY
+            )
+
+        set_source_files_properties(
+            ${CMAKE_CURRENT_BINARY_DIR}/${example}.hip PROPERTIES LANGUAGE HIP)
+
+        add_executable(${example}_hip ${CMAKE_CURRENT_BINARY_DIR}/${example}.hip)
+        target_compile_definitions(${example}_hip PRIVATE SOLVER_BACKEND_HIP)
+        target_link_libraries(${example}_hip amgcl_example hip_target)
+    endfunction()
+
+    add_hip_example(solver)
+endif()
+
 add_subdirectory(mpi)

--- a/examples/solver.cpp
+++ b/examples/solver.cpp
@@ -22,6 +22,10 @@
 #  include <amgcl/backend/cuda.hpp>
 #  include <amgcl/relaxation/cusparse_ilu0.hpp>
    typedef amgcl::backend::cuda<double> Backend;
+#elif defined(SOLVER_BACKEND_HIP)
+#  include <amgcl/backend/hip.hpp>
+#  include <amgcl/relaxation/rocsparse_ilu0.hpp>
+   typedef amgcl::backend::hip<double> Backend;
 #elif defined(SOLVER_BACKEND_EIGEN)
 #  include <amgcl/backend/eigen.hpp>
    typedef amgcl::backend::eigen<double> Backend;
@@ -258,6 +262,16 @@ std::tuple<size_t, double> scalar_solve(
         cudaGetDeviceProperties(&prop, dev);
         std::cout << prop.name << std::endl << std::endl;
     }
+#elif defined(SOLVER_BACKEND_HIP)
+    hipsparseCreate(&bprm.hipsparse_handle);
+    {
+        int dev;
+        hipGetDevice(&dev);
+
+        hipDeviceProp_t prop;
+        hipGetDeviceProperties(&prop, dev);
+        std::cout << prop.name << std::endl << std::endl;
+    }
 #endif
 
     typedef amgcl::make_solver<
@@ -294,7 +308,7 @@ std::tuple<size_t, double> scalar_solve(
         vex::copy(*x_b, tmp);
 #elif defined(SOLVER_BACKEND_VIENNACL)
         viennacl::fast_copy(*x_b, tmp);
-#elif defined(SOLVER_BACKEND_CUDA)
+#elif defined(SOLVER_BACKEND_CUDA) || defined(SOLVER_BACKEND_HIP)
         thrust::copy(x_b->begin(), x_b->end(), tmp.begin());
 #else
         std::copy(&(*x_b)[0], &(*x_b)[0] + rows, &tmp[0]);
@@ -319,7 +333,7 @@ std::tuple<size_t, double> scalar_solve(
         vex::copy(*x_b, x);
 #elif defined(SOLVER_BACKEND_VIENNACL)
         viennacl::fast_copy(*x_b, x);
-#elif defined(SOLVER_BACKEND_CUDA)
+#elif defined(SOLVER_BACKEND_CUDA) || defined(SOLVER_BACKEND_HIP)
         thrust::copy(x_b->begin(), x_b->end(), x.begin());
 #else
         std::copy(&(*x_b)[0], &(*x_b)[0] + rows, &x[0]);


### PR DESCRIPTION
This adds a native HIP/hipSPARSE backend to amgcl alongside the existing CUDA/cuSPARSE one. It is purely additive: two new headers, amgcl/backend/hip.hpp and amgcl/relaxation/rocsparse_ilu0.hpp, mirror amgcl/backend/cuda.hpp and amgcl/relaxation/cusparse_ilu0.hpp with cuSPARSE swapped for hipSPARSE (which exposes the same generic SpMV/SpSV API name-for-name) and Thrust kept as-is (rocThrust is a drop-in). The CUDA and builtin build paths are byte-for-byte unchanged; the HIP backend is reached via -DUSE_HIP=ON (library) and -DSOLVER_BACKEND_HIP (examples). amgcl previously reached AMD GPUs only through the OpenCL-based vexcl/viennacl backends; this gives it a native one. The new backend is documented alongside the others in docs/components/backends.rst.

Building with the HIP backend:
```
cmake -S . -B build -DUSE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx90a
cmake --build build
```

Test Plan:

Validated on AMD Instinct MI250X (gfx90a, CDNA2), Radeon Pro W7800 (gfx1100, RDNA3), Radeon PRO V710 (gfx1101, RDNA3, Windows), and Radeon RX 9070 XT (gfx1201, RDNA4, Windows), on a 7-point 3D Poisson system (SPD) from amgcl's own generator.

- The hip backend's solve matches the builtin (CPU) backend bit-for-bit: with the spai0 relaxation, both take 17 iterations to residual 3.36e-11.
- The hipSPARSE ilu0 relaxation (rocsparse_ilu0.hpp) converges in 11 iterations to residual 9.07e-11.
- The examples/solver_hip driver (3-level AMG + BiCGStab, spai0) solves the same system in 7 iterations to error 5.24e-09.

Authored with the assistance of Claude (Anthropic).
