### PR TITLE
Fix subscript out of range

### DIFF
--- a/amgcl/mpi/coarsening/pmis.hpp
+++ b/amgcl/mpi/coarsening/pmis.hpp
@@ -356,7 +356,7 @@ struct pmis {
         for(size_t i = 0, nv = C.send.count(); i < nv; ++i)
             D_loc[i] = D[C.send.col[i]];
 
-        C.exchange(&D_loc[0], &D_rem[0]);
+        C.exchange(D_loc.data(), D_rem.data());
 
         auto s_loc = std::make_shared<bool_matrix>();
         auto s_rem = std::make_shared<bool_matrix>();
@@ -476,7 +476,7 @@ struct pmis {
         // Exchange state
         for(ptrdiff_t i = 0, m = Sp.send.count(); i < m; ++i)
             send_state[i] = loc_state[Sp.send.col[i]];
-        Sp.exchange(&send_state[0], &rem_state[0]);
+        Sp.exchange(send_state.data(), rem_state.data());
 
         std::vector< std::vector<ptrdiff_t> > send_pts(Sp.recv.nbr.size());
         std::vector<ptrdiff_t> recv_pts;
@@ -628,7 +628,7 @@ struct pmis {
 
             for(ptrdiff_t i = 0, m = Sp.send.count(); i < m; ++i)
                 send_state[i] = loc_state[Sp.send.col[i]];
-            Sp.exchange(&send_state[0], &rem_state[0]);
+            Sp.exchange(send_state.data(), rem_state.data());
 
             if (0 == comm.reduce(MPI_SUM, n_undone))
                 break;
@@ -639,7 +639,7 @@ struct pmis {
         AMGCL_TIC("drop empty aggregates");
         for(ptrdiff_t i = 0, m = Sp.send.count(); i < m; ++i)
             send_owner[i] = loc_owner[Sp.send.col[i]];
-        Sp.exchange(&send_owner[0], &rem_owner[0]);
+        Sp.exchange(send_owner.data(), rem_owner.data());
 
         std::vector<ptrdiff_t> new_id(naggr + 1, 0);
         for(ptrdiff_t i = 0; i < n; ++i) {


### PR DESCRIPTION
When compiled and run with MSVC in debug mode using a single MPI process, an exception was thrown.

A similar case was discussed previously in PR #292. To be honest, I'm not sure whether this change completely prevents similar issues from occurring again. I searched the entire repository using the regular expression `&(\w+)\[0\]` and found quite a few matches.